### PR TITLE
GH-24: Add OOD fields to ARCHITECTURE and 6 PRDs

### DIFF
--- a/docs/ARCHITECTURE.yaml
+++ b/docs/ARCHITECTURE.yaml
@@ -272,6 +272,17 @@ design_decisions:
     alternatives_rejected:
       - Defining constants in the package that owns the concept scatters the lookup across multiple files
 
+shared_protocols:
+  - name: Cupboard
+    description: Storage lifecycle interface. Backends implement Attach, Detach, and GetTable to provide uniform access to all entity tables.
+    pattern: "caller imports pkg/api, calls Attach with Config, then GetTable for each entity type"
+  - name: Table
+    description: Uniform CRUD interface for all entity types. Get, Set, Delete, and Fetch operate on concrete entity structs via type assertions.
+    pattern: "one Table per entity type; callers use Table.Set to persist in-memory changes made by entity methods"
+  - name: Entity Methods
+    description: In-memory state-transition methods on entity structs (SetState, Pebble, Dust, Complete, Abandon, SetValue, Acquire, Release). Methods modify struct fields only. Callers persist via Table.Set.
+    pattern: "entity := table.Get(id); entity.Method(); table.Set(id, entity)"
+
 technology_choices:
   - component: Language
     technology: Go

--- a/docs/specs/product-requirements/prd001-cupboard-core.yaml
+++ b/docs/specs/product-requirements/prd001-cupboard-core.yaml
@@ -77,6 +77,21 @@ requirements:
     - R8.1: All entity IDs must be UUID v7 (time-ordered UUIDs per RFC 9562)
     - R8.2: Backends generate UUIDs when Set is called with an empty id parameter
     - R8.3: UUID v7 provides sortability by creation time without separate timestamp columns
+package_contract:
+  exports:
+    - name: Config
+      signature: "type Config struct { Backend string; DataDir string }"
+    - name: Cupboard
+      signature: "type Cupboard interface { GetTable(string) (Table, error); Attach(Config) error; Detach() error }"
+    - name: Table
+      signature: "type Table interface { Get(string) (any, error); Set(string, any) (string, error); Delete(string) error; Fetch(map[string]any) ([]any, error) }"
+    - name: ErrAlreadyAttached
+    - name: ErrCupboardDetached
+    - name: ErrTableNotFound
+    - name: ErrNotFound
+    - name: ErrInvalidID
+  import_constraints:
+    - "pkg/api must not import pkg/schema, internal/, or cmd/"
 non_goals:
 - This PRD does not define entity-specific schemas or operations. Entity types are defined in their respective interface PRDs
   (prd003-crumbs-interface, prd006-trails-interface, etc.).

--- a/docs/specs/product-requirements/prd002-sqlite-backend.yaml
+++ b/docs/specs/product-requirements/prd002-sqlite-backend.yaml
@@ -227,6 +227,33 @@ requirements:
         (temp file, fsync, rename)
     - R16.8: The sync strategy does not affect SQLite durability. SQLite transactions commit synchronously regardless of JSONL
         sync strategy
+package_contract:
+  exports:
+    - name: SQLiteConfig
+      signature: "type SQLiteConfig struct { SyncStrategy string; BatchSize int; BatchInterval time.Duration }"
+    - name: NewSQLiteBackend
+      signature: "func NewSQLiteBackend() api.Cupboard"
+    - name: HydrateCrumb
+      signature: "func HydrateCrumb(row sql.Row) (*schema.Crumb, error)"
+    - name: HydrateTrail
+      signature: "func HydrateTrail(row sql.Row) (*schema.Trail, error)"
+    - name: HydrateProperty
+      signature: "func HydrateProperty(row sql.Row) (*schema.Property, error)"
+    - name: PersistCrumb
+      signature: "func PersistCrumb(crumb *schema.Crumb) []any"
+    - name: PersistTrail
+      signature: "func PersistTrail(trail *schema.Trail) []any"
+    - name: PersistProperty
+      signature: "func PersistProperty(prop *schema.Property) []any"
+  imports:
+    - "pkg/api"
+    - "pkg/schema"
+    - "pkg/constants"
+    - "modernc.org/sqlite"
+  import_constraints:
+    - "internal/persistence must not import cmd/"
+    - "internal/persistence/engine must not import pkg/schema (entity-agnostic)"
+    - "internal/persistence/mapping must not import internal/persistence/engine"
 non_goals:
 - This PRD does not define the Cupboard interface operations. Those are in prd001-cupboard-core and the interface PRDs
 - This PRD does not define cross-process locking. Single-process access is assumed

--- a/docs/specs/product-requirements/prd003-crumbs-interface.yaml
+++ b/docs/specs/product-requirements/prd003-crumbs-interface.yaml
@@ -124,6 +124,22 @@ requirements:
     items:
     - R11.1: Crumb entity methods and Table operations must return the following sentinel errors
     - R11.2: All errors must be checkable with errors.Is
+package_contract:
+  exports:
+    - name: Crumb
+      signature: "type Crumb struct { CrumbID string; Name string; State string; CreatedAt time.Time; UpdatedAt time.Time; Properties map[string]any }"
+    - name: Crumb.SetState
+      signature: "func (c *Crumb) SetState(state string) error"
+    - name: Crumb.Pebble
+      signature: "func (c *Crumb) Pebble() error"
+    - name: Crumb.Dust
+      signature: "func (c *Crumb) Dust() error"
+    - name: Crumb.SetProperty
+      signature: "func (c *Crumb) SetProperty(propertyID string, value any) error"
+    - name: Crumb.GetProperty
+      signature: "func (c *Crumb) GetProperty(propertyID string) (any, error)"
+  import_constraints:
+    - "pkg/schema must not import pkg/api or internal/"
 non_goals:
 - This PRD does not define the Table interface or Cupboard interface. See prd001-cupboard-core
 - This PRD does not define trail operations. See prd006-trails-interface

--- a/docs/specs/product-requirements/prd004-properties-interface.yaml
+++ b/docs/specs/product-requirements/prd004-properties-interface.yaml
@@ -125,6 +125,16 @@ requirements:
     items:
     - R10.1: Property and Category operations must return the following sentinel errors
     - R10.2: All errors must be checkable with errors.Is
+package_contract:
+  exports:
+    - name: Property
+      signature: "type Property struct { PropertyID string; Name string; Description string; ValueType string; CreatedAt time.Time }"
+    - name: Category
+      signature: "type Category struct { CategoryID string; PropertyID string; Name string; Ordinal int }"
+    - name: Property.DefineCategory
+      signature: "func (p *Property) DefineCategory(name string, ordinal int) (*Category, error)"
+  import_constraints:
+    - "pkg/schema must not import pkg/api or internal/"
 non_goals:
 - This PRD does not define setting or getting property values on crumbs. See prd003-crumbs-interface for SetProperty, GetProperty,
   GetProperties, and ClearProperty

--- a/docs/specs/product-requirements/prd006-trails-interface.yaml
+++ b/docs/specs/product-requirements/prd006-trails-interface.yaml
@@ -105,6 +105,16 @@ requirements:
     - R9.5: To find the branch point of a trail, query the links table for a `branches_from` link where `from_id` equals the
         trail ID
     - R9.6: Trails without a `branches_from` link are standalone (not branched from any crumb)
+package_contract:
+  exports:
+    - name: Trail
+      signature: "type Trail struct { TrailID string; State string; CreatedAt time.Time; CompletedAt time.Time }"
+    - name: Trail.Complete
+      signature: "func (t *Trail) Complete() error"
+    - name: Trail.Abandon
+      signature: "func (t *Trail) Abandon() error"
+  import_constraints:
+    - "pkg/schema must not import pkg/api or internal/"
 non_goals:
 - This PRD does not define crumb CRUD operations. See prd003-crumbs-interface.
 - This PRD does not define the Table interface or link storage. The Table interface is defined in prd001-cupboard-core and

--- a/docs/specs/product-requirements/prd008-stash-interface.yaml
+++ b/docs/specs/product-requirements/prd008-stash-interface.yaml
@@ -135,6 +135,22 @@ requirements:
         the stash ID
     - R13.6: To find all stashes scoped to a trail, query the links table for `scoped_to` links where `to_id` equals the trail
         ID
+package_contract:
+  exports:
+    - name: Stash
+      signature: "type Stash struct { StashID string; Name string; StashType string; Value any; Version int; CreatedAt time.Time }"
+    - name: StashHistoryEntry
+      signature: "type StashHistoryEntry struct { StashID string; Version int; Operation string; Timestamp time.Time; Metadata map[string]any }"
+    - name: Stash.SetValue
+      signature: "func (s *Stash) SetValue(value any) error"
+    - name: Stash.Increment
+      signature: "func (s *Stash) Increment(delta int64) (int64, error)"
+    - name: Stash.Acquire
+      signature: "func (s *Stash) Acquire(holder string) error"
+    - name: Stash.Release
+      signature: "func (s *Stash) Release(holder string) error"
+  import_constraints:
+    - "pkg/schema must not import pkg/api or internal/"
 non_goals:
 - This PRD does not define queue or channel stash types. These may be added in a future version
 - This PRD does not define stash replication or cross-cupboard sharing


### PR DESCRIPTION
## Summary

Populates OOD specification fields (`shared_protocols`, `package_contract`) across the crumbs spec documents. These fields give measure and stitch agents structured API context when `measure_source_mode: headers` is active.

## Changes

- ARCHITECTURE.yaml: added `shared_protocols` for Cupboard, Table, and Entity Methods interfaces
- prd001-cupboard-core: `package_contract` with Config, Cupboard, Table exports and import constraints
- prd002-sqlite-backend: `package_contract` with SQLiteConfig, hydration/dehydration exports and import constraints
- prd003-crumbs-interface: `package_contract` with Crumb struct and entity method exports
- prd004-properties-interface: `package_contract` with Property, Category exports
- prd006-trails-interface: `package_contract` with Trail struct and lifecycle method exports
- prd008-stash-interface: `package_contract` with Stash, StashHistoryEntry exports

## Stats

7 files changed, 105 insertions

## Test plan

- [x] `mage analyze` passes with no new errors
- [x] OOD fields consistent with ARCHITECTURE component definitions
- [x] Documentation reviewed for consistency

Closes #24