### PR TITLE
GH-26: Upgrade cobbler-scaffold v0.20260306.0 → v0.20260308.2

### DIFF
--- a/docs/constitutions/design.yaml
+++ b/docs/constitutions/design.yaml
@@ -128,12 +128,28 @@ document_types:
       - goals (G1, G2, ...)
       - requirements (R1.1, R1.2, ..., grouped by R1, R2, ...)
       - non_goals
-      - acceptance_criteria
+      - acceptance_criteria (list of objects with id, criterion, traces)
     numbering:
       goals: "G1, G2, G3, ..."
       requirement_groups: "R1, R2, R3, ..."
       requirement_items: "R1.1, R1.2, R2.1, ..."
       requirement_id_format: "R{group}.{item} — numeric dotted only (e.g., R1.1, R2.3). Letter suffixes (R2a) are not valid and are flagged by mage analyze."
+      acceptance_criteria_ids: "AC1, AC2, AC3, ... (sequential within each PRD)"
+    acceptance_criteria_schema:
+      description: |
+        Each acceptance criterion is a structured object linking a checkable
+        statement to the requirement items it validates. Every R-item in the
+        PRD must appear in at least one AC's traces list.
+      fields:
+        - id: "AC1, AC2, ... (sequential)"
+        - criterion: "Checkable statement (the prose text)"
+        - traces: "List of R-item IDs this AC validates (e.g., [R1.1, R1.2])"
+      example: |
+        acceptance_criteria:
+          - id: AC1
+            criterion: Config struct includes all fields listed in R1 with YAML struct tags
+            traces: [R1.1, R1.2, R1.3]
+      completeness_rule: "Every R-item must appear in at least one AC's traces list"
     purpose: |
       Defines product requirements with numbered goals and requirements. Each
       requirement starts with "must" or "must not" or a concrete verb. No scope
@@ -150,12 +166,27 @@ document_types:
       - trigger
       - flow (F1, F2, ..., end-to-end steps)
       - touchpoints (T1, T2, ..., architecture elements exercised)
-      - success_criteria (S1, S2, ..., checkable outcomes)
+      - success_criteria (list of objects with id, criterion, traces)
       - out_of_scope
     numbering:
       flow_steps: "F1, F2, F3, ..."
       touchpoints: "T1, T2, T3, ..."
       success_criteria: "S1, S2, S3, ..."
+    success_criteria_schema:
+      description: |
+        Each success criterion is a structured object linking a checkable
+        outcome to the PRD acceptance criteria it exercises. The traces field
+        references PRD AC IDs using the format prdNNN-name ACN.
+      fields:
+        - id: "S1, S2, ... (sequential)"
+        - criterion: "Checkable outcome statement"
+        - traces: "List of PRD AC IDs (e.g., [prd001-orchestrator-core AC1])"
+      example: |
+        success_criteria:
+          - id: S1
+            criterion: New(config) returns a non-nil *Orchestrator
+            traces:
+              - prd001-orchestrator-core AC2
     purpose: |
       Describes a concrete usage of the architecture. One end-to-end path
       (tracer bullet) through the system. Leads to a proof-of-concept or demo.
@@ -170,6 +201,11 @@ document_types:
       - release (release ID this suite covers)
       - traces (list of use case IDs covered by this suite)
       - test_cases (list organized by use case sub-sections, each with name, inputs, expected outputs)
+    traces_format: |
+      The traces field in test_cases can reference three kinds of IDs:
+        - PRD R-item IDs: prdNNN-name RN.N (e.g., prd001-orchestrator-core R1.1)
+        - PRD AC IDs: prdNNN-name ACN (e.g., prd001-orchestrator-core AC1)
+        - UC S-item IDs: relNN.N-ucNNN-name SN (e.g., rel01.0-uc001-orchestrator-initialization S1)
     purpose: |
       Groups test cases for a full release. Each use case in the release appears
       as a sub-section within the suite. The YAML provides quick human/Claude
@@ -219,6 +255,36 @@ document_types:
       Defines releases with version, name, focus, and list of use cases with
       status. Use cases are assigned to releases. Release numbering: rel[NN].[N]
       (major.minor). Minor releases validate completed major releases.
+
+  generation_run_report:
+    location: "docs/reports/generation-run-[N].md (e.g., generation-run-15.md)"
+    format_rule: generation-run-report-format
+    required_fields:
+      - "title: 'Generation Run [N]: [total LOC] LOC, $[total cost] — [one-line summary]'"
+      - "Configuration section: generation branch name, base branch, cobbler version,
+          model, max_turns, preserve_sources flag, issues_repo"
+      - "Cycle-by-cycle results section: table with columns cycle, issue title, status
+          (pass/fail/restart), stitch turns used, input tokens, output tokens,
+          cost USD, LOC delta"
+      - "Measure cycles section: table with columns cycle, issues proposed, input
+          tokens, output tokens, cost USD"
+      - "Cost analysis section: total input tokens, total output tokens, total cost USD,
+          total LOC produced, cost per KLOC; comparison table against prior runs
+          (run number, date, total LOC, total cost, cost/KLOC)"
+      - "Generated packages section: list of packages or modules produced with their LOC"
+      - "Failures and restarts section: for each failed stitch, the issue title, error
+          summary, and whether it was retried or abandoned"
+    purpose: |
+      Captures the full accounting of a completed generation run so that cost
+      trends, failure patterns, and per-package productivity can be tracked
+      across runs. Written once per generation after generator:stop completes.
+
+      Data source: before writing the report, read all history files from the
+      generation branch's merged tag (.cobbler/history/ under the
+      <generation-branch>-merged git tag): *-stitch-stats.yaml,
+      *-measure-stats.yaml, and *-stitch-report.yaml. These files contain
+      per-cycle token counts, costs, LOC deltas, and failure records.
+      Do not estimate; read the files.
 
 naming_conventions:
   prd: "prd[NNN]-[feature-name].yaml (e.g., prd001-cupboard-core.yaml)"
@@ -271,14 +337,15 @@ completeness_checklists:
     - requirements are grouped (R1, R2, ...) with numbered items (R1.1, R1.2, ...)
     - Each requirement is specific and actionable
     - non_goals define what is out of scope
-    - acceptance_criteria are checkable without ambiguity
+    - acceptance_criteria are structured objects with id, criterion, and traces
+    - Every R-item appears in at least one AC's traces list
     - File saved as prd[NNN]-[feature-name].yaml
 
   use_case:
     - id matches filename without extension
     - flow steps are numbered (F1, F2, ...), end-to-end, map to real components
     - touchpoints are numbered (T1, T2, ...) and list interfaces, components, protocols
-    - success_criteria are numbered (S1, S2, ...) and checkable without ambiguity
+    - success_criteria are structured objects with id, criterion, and traces to PRD AC IDs
     - test_suite references a corresponding test suite ID
     - Test suite YAML exists and traces back to this use case
     - Use case added to appropriate release in road-map.yaml

--- a/docs/constitutions/go-style.yaml
+++ b/docs/constitutions/go-style.yaml
@@ -92,12 +92,15 @@ design_patterns:
       callback registration when the producer should not know about its consumers.
 
 interfaces: |
-  Introduce an interface when you have two concrete implementations or when you
-  need to mock a dependency in tests. Do not create an interface for a single
-  implementation "just in case." Accept interfaces as parameters; return concrete
-  structs. Keep interfaces small: one to three methods. A large interface is a
-  sign that the abstraction is wrong. Split it into focused interfaces and compose
-  them.
+  Every boundary between a parent package and its internal sub-packages must be
+  defined by an interface. The parent package declares the interface; the internal
+  sub-package provides a concrete type that satisfies it. This applies even when
+  only one implementation exists today. The purpose is testability and explicit
+  contracts at every package boundary, not speculative abstraction.
+
+  Accept interfaces as parameters; return concrete structs. Keep interfaces small:
+  one to three methods. A large interface is a sign that the abstraction is wrong.
+  Split it into focused interfaces and compose them.
 
   Do not use interface{} or any as function parameters, return types, or struct
   fields. Every value must have a concrete type or a named interface. If a
@@ -162,6 +165,23 @@ no_magic_strings: |
   new external command or path, define the constant first, then use it. Never
   scatter raw string literals across files.
 
+configuration_via_yaml: |
+  All configuration must flow through configuration.yaml, loaded into the Config
+  struct by LoadConfig(). Do not read os.Getenv() to control orchestrator
+  behaviour, select execution modes, set file paths, or pass any option that a
+  user would otherwise set in configuration.yaml. Environment variables are not
+  a configuration channel in this project.
+
+  os.Getenv() is permitted only for two purposes: reading platform context
+  provided by the operating system (HOME, PATH, TMPDIR) and, in test code only,
+  reading variables that the test harness itself sets to override behaviour for
+  the test process. In both cases, the env var must be documented at the call
+  site with a comment explaining why it cannot come from Config.
+
+  The concrete consequence: if you find yourself writing os.Getenv("SOME_MODE")
+  or os.LookupEnv("SOME_FLAG") outside of those two narrow contexts, stop and
+  add a field to the relevant Config sub-struct instead.
+
 constants: |
   Prefer typed constants over bare string or integer literals for values that
   form a fixed set. Give the type a name: type totalMode int, then define the
@@ -176,19 +196,21 @@ project_structure: |
   cmd/: Entry points. Minimal: parse flags, wire dependencies, start.
   internal/: Private implementation. Not importable outside this module. One
   package per component.
-  pkg/: Shared public types and interfaces. No implementation. The contract layer
-  between libraries.
+  pkg/: Public API surface. Exports types and delegates to internal sub-packages.
   tests/: Integration tests.
   magefiles/: Build tooling. Flat directory (mage constraint). One file per
   concern.
 
+  Every package organizes its implementation into internal/ sub-packages grouped
+  by domain concept. The parent package is the public API surface: it exports
+  types, defines interfaces, and delegates to internal sub-packages that provide
+  the implementation. Internal sub-packages are not importable outside the parent,
+  enforced by Go's internal/ directory convention. This rule applies uniformly to
+  packages under pkg/ and to top-level internal/ packages alike.
+
   Align package structure to PRD component structure. Each major component maps
   to one package. Avoid package names like util, common, helpers. Name packages
   by domain: storage, auth, config.
-
-  Define interfaces between major components. The pkg/ directory holds shared
-  types and interface contracts. The internal/ directory holds implementations
-  that satisfy those contracts.
 
 file_organization: |
   Name files by the concern or feature they implement: scaffold.go, stitch.go,
@@ -325,7 +347,7 @@ code_review_checklist:
   - "Every error is handled or explicitly discarded with a comment."
   - "Every struct has a single, nameable responsibility."
   - "No function exceeds 200 lines without a strong reason."
-  - "Interfaces are small (one to three methods) and have at least two implementations or a testing need."
+  - "Every sub-package boundary has an interface. Interfaces are small (one to three methods)."
   - "No boolean parameters toggle behavior that should be a Strategy or Decorator."
   - "Config structs embed shared fields rather than duplicating them."
   - "context.Context is threaded through I/O paths."
@@ -336,6 +358,7 @@ code_review_checklist:
   - "All receiver names are one- or two-letter abbreviations, consistent across all methods of the type."
   - "Imports are grouped: stdlib, external, internal — each group separated by a blank line."
   - "Every exported symbol has a godoc comment starting with the symbol name."
+  - "No os.Getenv() call controls orchestrator behaviour, execution mode, file paths, or any option that belongs in configuration.yaml."
   - "No init() function performs I/O or returns an error."
   - "No panic() is reachable from a runtime condition or user-provided input."
   - "Typed iota enums are used for any fixed set of integer values."
@@ -360,9 +383,10 @@ sections:
   - tag: interfaces
     title: Interfaces
     content: |
-      Introduce an interface only when two concrete implementations exist or a
-      dependency must be mocked in tests. Accept interfaces as parameters;
-      return concrete structs. Keep interfaces small: one to three methods.
+      Every boundary between a parent package and its internal sub-packages
+      must be defined by an interface, even when only one implementation exists.
+      Accept interfaces as parameters; return concrete structs. Keep interfaces
+      small: one to three methods.
   - tag: struct_and_function_design
     title: Struct and Function Design
     content: |
@@ -398,6 +422,15 @@ sections:
     content: |
       Centralize all string literals for binary names, file paths, URLs, and
       repeated text as named constants. Never scatter raw string literals.
+  - tag: configuration_via_yaml
+    title: Configuration via YAML Only
+    content: |
+      All configuration flows through configuration.yaml and the Config struct.
+      Do not use os.Getenv() to control orchestrator behaviour, execution modes,
+      or any option that belongs in configuration.yaml. os.Getenv() is
+      permitted only for platform context (HOME, PATH) and, in test code, for
+      variables the test harness itself sets.
+
   - tag: constants
     title: Constants and Iota
     content: |
@@ -408,8 +441,10 @@ sections:
     title: Project Structure
     content: |
       cmd/ for entry points, internal/ for private implementation, pkg/ for
-      public shared types, tests/ for integration tests, magefiles/ for build
-      tooling. Align package structure to PRD component structure.
+      public API surface, tests/ for integration tests, magefiles/ for build
+      tooling. Every package organizes implementation into internal/
+      sub-packages by domain concept. The parent package exports types and
+      delegates; internal sub-packages provide the implementation.
   - tag: file_organization
     title: File Organization
     content: |

--- a/docs/prompts/measure.yaml
+++ b/docs/prompts/measure.yaml
@@ -28,6 +28,7 @@ constraints: |
   - Do NOT duplicate existing issues. Review the issues in the project_context above before proposing.
   - Issues with status "closed" represent COMPLETED work. Do not re-propose work that a closed issue already covers, even under a different title or framing. The completed_work field in project_context lists all finished tasks — treat every entry as work that must not be repeated.
   - When source_code contains .go files for a package, that package already exists. Do not propose creating or reimplementing it. Trust the source code over prose descriptions in documentation (e.g., implementation_status sections in ARCHITECTURE.yaml may be stale).
+  - If the source code already fully implements all requirements for the current release and no meaningful implementation work remains, return an empty YAML list: ```yaml\n[]\n```. An empty list is the correct and expected output when the spec is complete. Do NOT propose verification tasks, clean-up tasks, or minor follow-ups just to produce output — return `[]` instead.
   - Components with a provided_by field in ARCHITECTURE.yaml are external infrastructure. Do NOT propose tasks that create or modify files in those components.
   - Do NOT exceed {limit} tasks. If more work is needed, create additional tasks in a future session.
   - Do NOT create tasks larger than {lines_max} lines of production code. Target {lines_min}-{lines_max} lines per task, touching 5-7 files. Split aggressively: a task that creates a struct and implements its methods is two tasks.

--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/magefile/mage v1.15.0
-	github.com/mesh-intelligence/cobbler-scaffold v0.20260306.0
+	github.com/mesh-intelligence/cobbler-scaffold v0.20260308.2
 )
 
 require (

--- a/magefiles/go.sum
+++ b/magefiles/go.sum
@@ -1,7 +1,7 @@
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
 github.com/magefile/mage v1.15.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260306.0 h1:WAAf/ERYINUyoQ1xgHl/UVFhGzdLHMdGhsg0Qb3Y6KY=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260306.0/go.mod h1:xFuIzON+/BqFbFCdpI26RqigNcaLuWACZIj7wT6T2QI=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260308.2 h1:tl6q5Uww1wUkH5t/CaUcmrFSgC6DcWKpnOU+xEkQW9E=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260308.2/go.mod h1:7ClERKqRLakydq2mwtElXc/uuNoiHD9SnKxndu8w5yg=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1 h1:8hho5wd5XU87q91ssEFeJmgS0whm6JTroqtwnaUQxcA=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1/go.mod h1:bH59LsKvDqUtYzW+6MNoaFEjcpMtfdvRNjQDCyfBJ+o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/magefiles/orchestrator.go
+++ b/magefiles/orchestrator.go
@@ -144,6 +144,9 @@ func (Stats) Loc() error { return newOrch().Stats() }
 // Tokens enumerates prompt-attached files and counts tokens via the Anthropic API.
 func (Stats) Tokens() error { return newOrch().TokenStats() }
 
+// Generator prints a status report for the current generation run.
+func (Stats) Generator() error { return newOrch().GeneratorStats() }
+
 // --- Prompt targets ---
 
 // Measure prints the assembled measure prompt to stdout.


### PR DESCRIPTION
## Summary

Upgrades cobbler-scaffold from v0.20260306.0 to v0.20260308.2, bringing in new analyze checks (schema validation, AC tracing, success criteria tracing), the eng09 specification-as-semantic-model guideline, and internal sub-package extraction upstream.

## Changes

- Updated magefiles/go.mod to cobbler-scaffold v0.20260308.2
- Updated docs/constitutions/design.yaml with new schema formats and traceability rules
- Updated docs/constitutions/go-style.yaml with internal sub-package and interface boundary rules
- Updated docs/prompts/measure.yaml with new prompt content
- Updated magefiles/orchestrator.go with new mage targets

## Stats

- go_loc_prod: 0 (unchanged)
- spec_words: prd 18131, test_suite 15720, use_case 13426 (unchanged)
- 6 files changed, +131/-25 lines

## Test plan

- [x] `mage analyze` — no new errors (new checks surface pre-existing spec issues)
- [x] All previous analyze checks pass clean
- [x] Local customizations (configuration.yaml) preserved

Closes #26