### PR TITLE
GH-52: Audit specs for shared code — add prd013 and prd014

### DIFF
--- a/docs/ARCHITECTURE.yaml
+++ b/docs/ARCHITECTURE.yaml
@@ -319,8 +319,14 @@ project_structure:
   - path: internal/persistence/mapping/
     role: "Translation — hydration (SQL row to entity struct) and dehydration (entity struct to SQL params) for all entity types. One mapper per entity type. The only place that knows both field names and column names. Implements prd002-sqlite-backend R14, R15."
 
+  - path: internal/persistence/queryutil/
+    role: "Query helpers — Scanner interface, filter building (AddStringFilter, AddIntFilter), pagination (ApplyLimitOffset), result iteration (FetchRows), and single-row retrieval (GetByID). Entity-agnostic; operates on generic SQL types and callbacks. No dependency on pkg/schema or entity-specific code. Implements prd013-table-query-helpers."
+
+  - path: internal/persistence/lifecycle/
+    role: "Entity lifecycle — UUID v7 generation with timestamp (NewEntityID), upsert scaffolding (UpsertInTx), and delete scaffolding (DeleteInTx). Entity-agnostic; manages transaction lifecycle and calls entity-specific callbacks. No dependency on pkg/schema or entity-specific code. Implements prd014-entity-lifecycle-helpers."
+
   - path: internal/persistence/
-    role: "Persistence — Table interface implementations for all entity types. One file per entity table (crumbs_table.go, trails_table.go, etc.). Imports pkg/api, pkg/schema, pkg/constants, and internal/persistence/engine and mapping. Implements cascade operations for trail complete and abandon. Implements prd002-sqlite-backend R12-R13, prd003-crumbs-interface R6-R10, prd004-properties-interface R4-R6, prd005-metadata-interface R4-R8, prd006-trails-interface R3-R4, prd007-links-interface R3-R4, prd008-stash-interface R3, R8-R11."
+    role: "Persistence — Table interface implementations for all entity types. One file per entity table (crumbs_table.go, trails_table.go, etc.). Imports pkg/api, pkg/schema, pkg/constants, internal/persistence/engine, mapping, queryutil, and lifecycle. Implements cascade operations for trail complete and abandon. Implements prd002-sqlite-backend R12-R13, prd003-crumbs-interface R6-R10, prd004-properties-interface R4-R6, prd005-metadata-interface R4-R8, prd006-trails-interface R3-R4, prd007-links-interface R3-R4, prd008-stash-interface R3, R8-R11."
 
   - path: cmd/cupboard/
     role: "CLI entrypoint — cobra commands, config loading, output formatting. One file per command group. Imports pkg/api and pkg/schema only; never imports internal/. Implements prd009-cupboard-cli, prd010-configuration-directories R1, R8."

--- a/docs/specs/product-requirements/prd013-table-query-helpers.yaml
+++ b/docs/specs/product-requirements/prd013-table-query-helpers.yaml
@@ -1,0 +1,136 @@
+id: prd013-table-query-helpers
+title: Table Query Helpers
+problem: |
+  Every table accessor in the SQLite backend (crumbs, trails, links, stashes, properties,
+  metadata, categories) implements the same query-building and result-handling patterns
+  independently. The Fetch method in each table constructs WHERE clauses for string equality
+  filters using identical 8-line blocks, extracts limit/offset pagination using identical
+  20-line blocks, and iterates query results with identical 18-line blocks. The Get method
+  repeats the same 15-line pattern (validate ID, QueryRow, hydrate, map ErrNoRows to
+  ErrNotFound) in all seven files. Hydration functions exist in duplicate pairs — one for
+  *sql.Row and one for *sql.Rows — because Go's database/sql package uses two different
+  types for single-row and multi-row results, even though both support the same Scan method.
+
+  In the previous generation (commit 3745256), this duplication accounted for approximately
+  490 lines across 2,772 total lines of table code. The duplication violates the DRY
+  principle and increases the maintenance surface: a bug in filter parsing or result
+  iteration must be fixed in seven places.
+
+  We extract these patterns into a shared query helpers package within internal/persistence.
+  Table accessors call shared functions instead of reimplementing the same logic.
+
+goals:
+- G1: Eliminate duplicated query-building logic across table accessors
+- G2: Eliminate duplicated result-handling logic across table accessors
+- G3: Eliminate duplicated hydration function pairs across table accessors
+- G4: Provide a shared Get-by-ID pattern that all table accessors use
+
+requirements:
+  D:
+    title: Design Decisions
+    items:
+    - R0.1: The query helpers package lives at internal/persistence/queryutil. It has no
+        dependency on entity types (pkg/schema) or on specific table implementations. It
+        operates on generic SQL types and callback functions.
+    - R0.2: Table accessors in internal/persistence/ import queryutil. The queryutil package
+        must not import any package under internal/persistence/ except itself.
+  R1:
+    title: Scanner Interface
+    items:
+    - R1.1: Define a Scanner interface with a single method Scan(dest ...any) error
+    - R1.2: Both *sql.Row and *sql.Rows satisfy this interface without adapters
+    - R1.3: All hydration functions accept Scanner instead of *sql.Row or *sql.Rows, eliminating
+        the need for separate hydrate and hydrateFromRows functions per entity type
+  R2:
+    title: Filter Building
+    items:
+    - R2.1: Provide AddStringFilter that extracts a string value from the filter map by a given
+        field name, appends a WHERE condition for the mapped column name, and appends the value
+        to the args slice. Returns ErrInvalidFilter if the value is not a string
+    - R2.2: Provide AddIntFilter that does the same for integer filter values
+    - R2.3: Filter functions accept pointers to the conditions slice and args slice, mutating
+        them in place
+  R3:
+    title: Pagination
+    items:
+    - R3.1: Provide ApplyLimitOffset that extracts "limit" and "offset" from the filter map
+        and appends LIMIT and OFFSET clauses to the query string
+    - R3.2: Return ErrInvalidFilter if limit or offset values are present but not integers
+    - R3.3: Ignore limit or offset values that are zero or negative
+  R4:
+    title: Result Iteration
+    items:
+    - R4.1: Provide FetchRows that executes a query, iterates the result set, calls a
+        caller-provided hydration function for each row, and returns a slice of any
+    - R4.2: FetchRows must close the rows when done and check rows.Err after iteration
+    - R4.3: FetchRows must return an empty non-nil slice (not nil) when no rows match
+  R5:
+    title: Get By ID
+    items:
+    - R5.1: Provide GetByID that validates the id is non-empty (returns ErrInvalidID),
+        executes a QueryRow, calls a caller-provided hydration function, and maps
+        sql.ErrNoRows to ErrNotFound
+    - R5.2: GetByID accepts the query string and the hydration function as parameters
+  R6:
+    title: Existence Check
+    items:
+    - R6.1: Provide CheckExists that runs a SELECT 1 query for a given ID and returns
+        ErrNotFound if no row exists
+    - R6.2: Provide CheckUnique that runs a uniqueness query and returns ErrDuplicateName
+        if a matching row exists (excluding the current entity's ID)
+
+non_goals:
+- This PRD does not define entity-specific hydration logic. Each table accessor still defines
+    its own hydration function; this PRD provides the Scanner interface they accept
+- This PRD does not define transaction management. Transaction begin/commit/rollback remains
+    in each table accessor
+- This PRD does not define JSONL persistence helpers. JSONL operations remain in the engine package
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "Package lives at internal/persistence/queryutil with no dependency on pkg/schema, engine, or mapping; table accessors import queryutil"
+    traces: [R0.1, R0.2]
+  - id: AC2
+    criterion: Scanner interface defined and used by all hydration functions instead of *sql.Row/*sql.Rows pairs
+    traces: [R1.1, R1.2, R1.3]
+  - id: AC3
+    criterion: AddStringFilter and AddIntFilter extract filter values and build WHERE conditions
+    traces: [R2.1, R2.2, R2.3]
+  - id: AC4
+    criterion: ApplyLimitOffset extracts pagination from filter map and appends SQL clauses
+    traces: [R3.1, R3.2, R3.3]
+  - id: AC5
+    criterion: FetchRows executes query, iterates with hydration callback, returns non-nil empty slice on no results
+    traces: [R4.1, R4.2, R4.3]
+  - id: AC6
+    criterion: GetByID validates ID, hydrates single row, maps ErrNoRows to ErrNotFound
+    traces: [R5.1, R5.2]
+  - id: AC7
+    criterion: CheckExists and CheckUnique provide reusable existence and uniqueness validation
+    traces: [R6.1, R6.2]
+
+package_contract:
+  exports:
+    - name: Scanner
+      signature: "type Scanner interface { Scan(dest ...any) error }"
+    - name: AddStringFilter
+      signature: "func AddStringFilter(filter map[string]any, key string, column string, conditions *[]string, args *[]any) error"
+    - name: AddIntFilter
+      signature: "func AddIntFilter(filter map[string]any, key string, column string, conditions *[]string, args *[]any) error"
+    - name: ApplyLimitOffset
+      signature: "func ApplyLimitOffset(query *string, filter map[string]any) error"
+    - name: FetchRows
+      signature: "func FetchRows(db *sql.DB, query string, args []any, hydrate func(Scanner) (any, error)) ([]any, error)"
+    - name: GetByID
+      signature: "func GetByID(db *sql.DB, query string, id string, hydrate func(Scanner) (any, error)) (any, error)"
+    - name: CheckExists
+      signature: "func CheckExists(db *sql.DB, query string, id string) error"
+    - name: CheckUnique
+      signature: "func CheckUnique(db *sql.DB, query string, args ...any) error"
+  imports:
+    - "database/sql"
+    - "pkg/api"
+  import_constraints:
+    - "internal/persistence/queryutil must not import pkg/schema"
+    - "internal/persistence/queryutil must not import internal/persistence/engine"
+    - "internal/persistence/queryutil must not import internal/persistence/mapping"

--- a/docs/specs/product-requirements/prd014-entity-lifecycle-helpers.yaml
+++ b/docs/specs/product-requirements/prd014-entity-lifecycle-helpers.yaml
@@ -1,0 +1,111 @@
+id: prd014-entity-lifecycle-helpers
+title: Entity Lifecycle Helpers
+problem: |
+  Every table accessor in the SQLite backend repeats the same entity creation scaffolding:
+  generate a UUID v7, capture the current UTC time, assign both to the entity struct, then
+  branch between INSERT and UPDATE based on whether a row with that ID already exists. The
+  Delete method repeats a similar pattern: validate the ID, check existence, begin a
+  transaction, execute the delete within the transaction, commit, then persist to JSONL.
+
+  In the previous generation (commit 3745256), these patterns accounted for approximately
+  217 lines of duplication across 2,772 total lines of table code. Each table accessor
+  independently generated UUIDs, checked existence, and managed transaction scaffolding.
+  The Set method's INSERT-vs-UPDATE branching alone was 15-20 lines repeated in all seven
+  table files.
+
+  We extract these entity lifecycle operations into a shared package. Table accessors call
+  shared functions for ID generation, existence-based upsert scaffolding, and delete
+  scaffolding, then add entity-specific logic within callbacks.
+
+goals:
+- G1: Eliminate duplicated UUID v7 generation and timestamp initialization across table accessors
+- G2: Eliminate duplicated INSERT-vs-UPDATE existence check and transaction scaffolding
+- G3: Eliminate duplicated Delete existence check and transaction scaffolding
+
+requirements:
+  D:
+    title: Design Decisions
+    items:
+    - R0.1: The entity lifecycle helpers package lives at internal/persistence/lifecycle. It
+        has no dependency on entity types (pkg/schema) or on specific table implementations.
+        It operates on *sql.DB and callback functions.
+    - R0.2: Table accessors in internal/persistence/ import lifecycle. The lifecycle package
+        must not import any package under internal/persistence/ except itself.
+    - R0.3: Lifecycle helpers manage the transaction and existence-check scaffolding but do
+        not execute entity-specific SQL. Entity-specific INSERT, UPDATE, and DELETE statements
+        remain in each table accessor, passed as callbacks.
+  R1:
+    title: Entity ID Generation
+    items:
+    - R1.1: Provide NewEntityID that generates a UUID v7 string and returns the current UTC
+        time alongside it. Returns an error if UUID generation fails
+    - R1.2: The returned time is used by callers to set CreatedAt and UpdatedAt fields
+        consistently from a single time.Now call
+  R2:
+    title: Upsert Scaffolding
+    items:
+    - R2.1: Provide UpsertInTx that checks whether a row with the given ID exists, begins
+        a transaction, and calls either an insert callback or an update callback depending
+        on the existence check result
+    - R2.2: UpsertInTx accepts the database, a check query (e.g., "SELECT 1 FROM crumbs
+        WHERE crumb_id = ?"), the ID, an insert callback func(tx *sql.Tx) error, and an
+        update callback func(tx *sql.Tx) error
+    - R2.3: UpsertInTx must defer tx.Rollback and call tx.Commit only if the callback
+        succeeds. The deferred Rollback is a no-op after Commit
+    - R2.4: Return the open transaction's commit error or the callback error, whichever
+        occurs first
+    - R2.5: UpsertInTx must return a boolean indicating whether the operation was an insert
+        (true) or update (false), so callers can perform post-commit actions like JSONL
+        persistence that differ by operation type
+  R3:
+    title: Delete Scaffolding
+    items:
+    - R3.1: Provide DeleteInTx that validates the ID is non-empty (returns ErrInvalidID),
+        checks existence (returns ErrNotFound if missing), begins a transaction, and calls
+        a delete callback
+    - R3.2: DeleteInTx accepts the database, a check query, the ID, and a delete callback
+        func(tx *sql.Tx) error
+    - R3.3: DeleteInTx must defer tx.Rollback and call tx.Commit only if the callback
+        succeeds
+    - R3.4: Callers use the delete callback to execute entity-specific CASCADE deletes
+        (e.g., deleting a crumb's properties, metadata, and links within the same transaction)
+
+non_goals:
+- This PRD does not define JSONL persistence after commit. Table accessors handle JSONL
+    writes after the transaction completes, since JSONL file selection varies by entity type
+- This PRD does not define cascade logic. Cascade operations (trail complete/abandon) remain
+    in the table accessor's callback functions
+- This PRD does not define entity-specific validation. Name validation, state transition
+    checks, and type assertions remain in each table accessor
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "Package lives at internal/persistence/lifecycle with no dependency on pkg/schema, engine, mapping, or queryutil; entity-specific logic passed via callbacks"
+    traces: [R0.1, R0.2, R0.3]
+  - id: AC2
+    criterion: NewEntityID generates UUID v7 and returns UTC timestamp in a single call
+    traces: [R1.1, R1.2]
+  - id: AC3
+    criterion: UpsertInTx checks existence, begins transaction, calls insert or update callback, commits
+    traces: [R2.1, R2.2, R2.3, R2.4, R2.5]
+  - id: AC4
+    criterion: DeleteInTx validates ID, checks existence, begins transaction, calls delete callback, commits
+    traces: [R3.1, R3.2, R3.3, R3.4]
+
+package_contract:
+  exports:
+    - name: NewEntityID
+      signature: "func NewEntityID() (string, time.Time, error)"
+    - name: UpsertInTx
+      signature: "func UpsertInTx(db *sql.DB, checkQuery string, id string, onInsert func(tx *sql.Tx) error, onUpdate func(tx *sql.Tx) error) (inserted bool, err error)"
+    - name: DeleteInTx
+      signature: "func DeleteInTx(db *sql.DB, checkQuery string, id string, onDelete func(tx *sql.Tx) error) error"
+  imports:
+    - "database/sql"
+    - "github.com/google/uuid"
+    - "pkg/api"
+  import_constraints:
+    - "internal/persistence/lifecycle must not import pkg/schema"
+    - "internal/persistence/lifecycle must not import internal/persistence/engine"
+    - "internal/persistence/lifecycle must not import internal/persistence/mapping"
+    - "internal/persistence/lifecycle must not import internal/persistence/queryutil"


### PR DESCRIPTION
## Summary

Audited the previous generation's table implementations (commit 3745256, 2,772 lines across 7 table files) and found 31% duplication. Created two PRDs for shared helper packages that would eliminate ~680 lines net.

## Changes

- prd013-table-query-helpers: Scanner interface, filter building (AddStringFilter, AddIntFilter), pagination (ApplyLimitOffset), result iteration (FetchRows), single-row retrieval (GetByID), existence/uniqueness checks. Package: internal/persistence/queryutil.
- prd014-entity-lifecycle-helpers: UUID v7 + timestamp generation (NewEntityID), upsert scaffolding (UpsertInTx), delete scaffolding (DeleteInTx). Package: internal/persistence/lifecycle.
- ARCHITECTURE.yaml: Added queryutil and lifecycle to project_structure.

## Stats

- go_loc: 0 (no change)
- spec_words: prd 21,059 (+1,745), test_suite 15,720, use_case 14,286

## Test plan

- [x] `mage analyze` passes (0 uncovered R-items, 0 broken citations, 0 schema errors)
- [x] PRD format follows design constitution (id, title, problem, goals, requirements, non_goals, acceptance_criteria, package_contract)
- [x] All R-items traced by acceptance criteria

Closes #52