### PR TITLE
GH-54: Upgrade cobbler-scaffold v0.20260323.0 → v0.20260404.0, rename PRD → SRD

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A storage system for work items with built-in support for exploratory work sessi
 
 ## About This Repository
 
-This repository does not contain released application code. The deliverables are **requirements** (PRDs, use cases, architecture docs) and **build tooling** (mage targets). Application code is generated automatically by running `mage generator:start` followed by `mage generator:run`, which invokes Claude to produce Go source code from the specifications.
+This repository does not contain released application code. The deliverables are **requirements** (SRDs, use cases, architecture docs) and **build tooling** (mage targets). Application code is generated automatically by running `mage generator:start` followed by `mage generator:run`, which invokes Claude to produce Go source code from the specifications.
 
 Each completed generation is tagged and merged into main. To see past generations and their tags, run `mage generator:list`. To check out the code from a specific generation, use `git checkout <tag>` with one of the generation tags (e.g. `generation-2026-02-10-15-04-30-merged`).
 
@@ -138,7 +138,7 @@ crumbs/
 ├── cmd/cupboard/        # CLI entry point (generated)
 ├── pkg/types/           # Public API: interfaces and types (generated)
 ├── internal/sqlite/     # SQLite backend implementation (generated)
-├── docs/                # Documentation (VISION, ARCHITECTURE, PRDs)
+├── docs/                # Documentation (VISION, ARCHITECTURE, SRDs)
 ├── magefiles/           # Mage build targets (thin wrappers over library)
 ├── configuration.yaml   # Orchestrator settings
 ├── .beads/              # Beads issue tracker (managed by bd CLI)
@@ -162,7 +162,7 @@ Invoke these commands in Claude Code by typing the command name (e.g., `/do-work
 | `/bootstrap` | Start a new project: create initial VISION.md and ARCHITECTURE.md |
 | `/make-work` | Analyze project state and propose new epics and issues |
 | `/do-work` | Pick up available work and implement it |
-| `/do-work-docs` | Work on documentation tasks (PRDs, use cases) |
+| `/do-work-docs` | Work on documentation tasks (SRDs, use cases) |
 | `/do-work-code` | Work on implementation tasks |
 
 ### Workflow
@@ -190,7 +190,7 @@ bd sync               # Sync with git
 | -------- | -------- |
 | Vision | [docs/VISION.md](docs/VISION.md) |
 | Architecture | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) |
-| PRDs | [docs/specs/product-requirements/](docs/specs/product-requirements/) |
+| SRDs | [docs/specs/software-requirements/](docs/specs/software-requirements/) |
 | Use Cases | [docs/specs/use-cases/](docs/specs/use-cases/) |
 
 ## License

--- a/docs/ARCHITECTURE.yaml
+++ b/docs/ARCHITECTURE.yaml
@@ -19,7 +19,7 @@ overview:
     (time-ordered, sortable).
 
   lifecycle: |
-    Crumb states (prd003-crumbs-interface R2): draft -> pending -> ready -> taken -> pebble or dust.
+    Crumb states (srd003-crumbs-interface R2): draft -> pending -> ready -> taken -> pebble or dust.
     Terminal states are pebble (completed successfully) and dust (failed or abandoned). Named
     transition methods exist only for semantically distinct endpoints: Pebble() and Dust() for
     crumbs; other transitions use SetState.
@@ -55,36 +55,36 @@ interfaces:
       the backend type and data directory. SQLiteConfig extends Config with sync strategy,
       batch size, and batch interval settings.
     data_structures:
-      - "Config: backend selection and configuration (Backend, DataDir). See prd001-cupboard-core R1."
-      - "SQLiteConfig: SQLite-specific configuration for sync strategy, batch size, and batch interval. See prd002-sqlite-backend R16."
+      - "Config: backend selection and configuration (Backend, DataDir). See srd001-cupboard-core R1."
+      - "SQLiteConfig: SQLite-specific configuration for sync strategy, batch size, and batch interval. See srd002-sqlite-backend R16."
     operations:
-      - "GetTable(name string) (Table, error): returns a Table accessor for the given entity type. See prd001-cupboard-core R2."
-      - "Attach(config Config) error: opens the backend and loads data. See prd001-cupboard-core R2."
-      - "Detach() error: closes the backend and flushes pending writes. See prd001-cupboard-core R2."
-      - "Table.Get(id string) (any, error): retrieve a single entity by ID. See prd001-cupboard-core R3."
-      - "Table.Set(id string, data any) (string, error): create or update an entity. See prd001-cupboard-core R3."
-      - "Table.Delete(id string) error: remove an entity. See prd001-cupboard-core R3."
-      - "Table.Fetch(filter map[string]any) ([]any, error): query entities by filter. See prd001-cupboard-core R3."
+      - "GetTable(name string) (Table, error): returns a Table accessor for the given entity type. See srd001-cupboard-core R2."
+      - "Attach(config Config) error: opens the backend and loads data. See srd001-cupboard-core R2."
+      - "Detach() error: closes the backend and flushes pending writes. See srd001-cupboard-core R2."
+      - "Table.Get(id string) (any, error): retrieve a single entity by ID. See srd001-cupboard-core R3."
+      - "Table.Set(id string, data any) (string, error): create or update an entity. See srd001-cupboard-core R3."
+      - "Table.Delete(id string) error: remove an entity. See srd001-cupboard-core R3."
+      - "Table.Fetch(filter map[string]any) ([]any, error): query entities by filter. See srd001-cupboard-core R3."
 
   - name: Entity Types
     summary: |
       In-memory domain objects with state-transition methods. Entity methods modify struct fields
       only — no I/O, no database knowledge. All entities use UUID v7 identifiers.
     data_structures:
-      - "Crumb: work item with CrumbID, Name, State, CreatedAt, UpdatedAt, Properties. See prd003-crumbs-interface."
-      - "Trail: exploration session with TrailID, State, CreatedAt, CompletedAt. See prd006-trails-interface."
-      - "Property: property definition with PropertyID, Name, Description, ValueType, CreatedAt. See prd004-properties-interface."
-      - "Category: categorical value with CategoryID, PropertyID, Name, Ordinal. See prd004-properties-interface."
-      - "Stash: shared state with StashID, Name, StashType, Value, Version, CreatedAt. See prd008-stash-interface."
-      - "Metadata: supplementary data with MetadataID, CrumbID, TableName, Content, PropertyID, CreatedAt. See prd005-metadata-interface."
-      - "Link: typed directed edge with LinkID, LinkType, FromID, ToID, CreatedAt. Types: belongs_to, child_of, branches_from, scoped_to. See prd007-links-interface."
+      - "Crumb: work item with CrumbID, Name, State, CreatedAt, UpdatedAt, Properties. See srd003-crumbs-interface."
+      - "Trail: exploration session with TrailID, State, CreatedAt, CompletedAt. See srd006-trails-interface."
+      - "Property: property definition with PropertyID, Name, Description, ValueType, CreatedAt. See srd004-properties-interface."
+      - "Category: categorical value with CategoryID, PropertyID, Name, Ordinal. See srd004-properties-interface."
+      - "Stash: shared state with StashID, Name, StashType, Value, Version, CreatedAt. See srd008-stash-interface."
+      - "Metadata: supplementary data with MetadataID, CrumbID, TableName, Content, PropertyID, CreatedAt. See srd005-metadata-interface."
+      - "Link: typed directed edge with LinkID, LinkType, FromID, ToID, CreatedAt. Types: belongs_to, child_of, branches_from, scoped_to. See srd007-links-interface."
     operations:
-      - "Crumb.Pebble(): transition to terminal pebble state. See prd003-crumbs-interface."
-      - "Crumb.Dust(): transition to terminal dust state. See prd003-crumbs-interface."
-      - "Crumb.SetState(state): generic state transition. See prd003-crumbs-interface."
-      - "Trail.Complete(): transition trail and cascade crumbs to pebble. See prd006-trails-interface."
-      - "Trail.Abandon(): transition trail and cascade crumbs to dust. See prd006-trails-interface."
-      - "Stash.SetValue(), Stash.Increment(), Stash.Acquire(), Stash.Release(), Stash.GetHistory(). See prd008-stash-interface."
+      - "Crumb.Pebble(): transition to terminal pebble state. See srd003-crumbs-interface."
+      - "Crumb.Dust(): transition to terminal dust state. See srd003-crumbs-interface."
+      - "Crumb.SetState(state): generic state transition. See srd003-crumbs-interface."
+      - "Trail.Complete(): transition trail and cascade crumbs to pebble. See srd006-trails-interface."
+      - "Trail.Abandon(): transition trail and cascade crumbs to dust. See srd006-trails-interface."
+      - "Stash.SetValue(), Stash.Increment(), Stash.Acquire(), Stash.Release(), Stash.GetHistory(). See srd008-stash-interface."
 
 components:
   - name: Interfaces (pkg/api)
@@ -94,7 +94,7 @@ components:
       - Defines Table interface (Get, Set, Delete, Fetch)
       - Defines Config and SQLiteConfig structs with Validate methods
     references:
-      - prd001-cupboard-core R2, R3
+      - srd001-cupboard-core R2, R3
 
   - name: Entity Types (pkg/schema)
     responsibility: In-memory domain logic. Structs (Crumb, Trail, Property, Category, Stash, Metadata, Link) and their methods (SetState, Pebble, Dust, Complete, Abandon, etc.). Methods update struct fields only — no I/O, no database knowledge. No dependency on pkg/api or internal/.
@@ -104,12 +104,12 @@ components:
       - Stash struct with value methods (SetValue, Increment, Acquire, Release)
       - Property, Category, Metadata, Link, Schema structs
     references:
-      - prd003-crumbs-interface
-      - prd006-trails-interface
-      - prd008-stash-interface
-      - prd004-properties-interface
-      - prd005-metadata-interface
-      - prd007-links-interface
+      - srd003-crumbs-interface
+      - srd006-trails-interface
+      - srd008-stash-interface
+      - srd004-properties-interface
+      - srd005-metadata-interface
+      - srd007-links-interface
 
   - name: Constants (pkg/constants)
     responsibility: Single source of truth for all domain strings. State values, link types, property defaults, sync strategies, and table names are defined here as named constants. No package in the codebase uses raw string literals for these values.
@@ -128,7 +128,7 @@ components:
       - JSONL read/write with atomic rename
       - Sync strategy implementations (immediate, on_close, batch)
     references:
-      - prd002-sqlite-backend R3, R4, R14, R16
+      - srd002-sqlite-backend R3, R4, R14, R16
 
   - name: SQL Mapping (internal/persistence/mapping)
     responsibility: Entity-to-SQL row translation. One mapper per entity type converts between Go structs and SQL column values. This package is the only place that knows both entity field names and SQL column names. Adding a column means changing a mapper, not the engine or the interface.
@@ -136,7 +136,7 @@ components:
       - Hydration (SQL row to entity struct) for all entity types
       - Dehydration (entity struct to SQL params) for all entity types
     references:
-      - prd002-sqlite-backend R5, R6, R7, R8, R9, R10, R11, R12, R13
+      - srd002-sqlite-backend R5, R6, R7, R8, R9, R10, R11, R12, R13
 
   - name: CLI (cmd/cupboard)
     responsibility: Command-line tool for development and personal use. Commands map to Cupboard operations. Config file selects backend. Supports generic table commands and issue-tracking commands.
@@ -146,8 +146,8 @@ components:
       - JSON output flag for scripting
       - Platform-specific configuration directory resolution
     references:
-      - prd009-cupboard-cli
-      - prd010-configuration-directories
+      - srd009-cupboard-cli
+      - srd010-configuration-directories
 
 design_decisions:
   - id: 1
@@ -305,31 +305,31 @@ technology_choices:
 
 project_structure:
   - path: pkg/api/
-    role: "Intent — Cupboard and Table interfaces, Config, SQLiteConfig, sentinel errors. The only package callers import. Implements prd001-cupboard-core R1-R3, R6-R7."
+    role: "Intent — Cupboard and Table interfaces, Config, SQLiteConfig, sentinel errors. The only package callers import. Implements srd001-cupboard-core R1-R3, R6-R7."
 
   - path: pkg/schema/
-    role: "Domain — all entity structs and state-transition methods (Crumb, Trail, Property, Category, Stash, Metadata, Link, StashHistoryEntry). No dependency on pkg/api or internal/. One file per entity type. Implements prd003-crumbs-interface, prd004-properties-interface, prd005-metadata-interface, prd006-trails-interface, prd007-links-interface R1, prd008-stash-interface R1-R7."
+    role: "Domain — all entity structs and state-transition methods (Crumb, Trail, Property, Category, Stash, Metadata, Link, StashHistoryEntry). No dependency on pkg/api or internal/. One file per entity type. Implements srd003-crumbs-interface, srd004-properties-interface, srd005-metadata-interface, srd006-trails-interface, srd007-links-interface R1, srd008-stash-interface R1-R7."
 
   - path: pkg/constants/
-    role: "Rules — all domain strings as named constants: state values, link types, table names, sync strategies, stash operation codes, property value types. No package uses raw string literals. Authoritative location for constants referenced by prd007-links-interface R2.2 and prd008-stash-interface R2, R7.3. Implements prd001-cupboard-core R2.5, prd002-sqlite-backend R2."
+    role: "Rules — all domain strings as named constants: state values, link types, table names, sync strategies, stash operation codes, property value types. No package uses raw string literals. Authoritative location for constants referenced by srd007-links-interface R2.2 and srd008-stash-interface R2, R7.3. Implements srd001-cupboard-core R2.5, srd002-sqlite-backend R2."
 
   - path: internal/persistence/engine/
-    role: "Infrastructure — SQLite lifecycle, JSONL flush, RWMutex, atomic write pattern (temp file, fsync, rename). Knows nothing about entity types. Implements prd002-sqlite-backend R1-R11, R16, prd010-configuration-directories R4-R7."
+    role: "Infrastructure — SQLite lifecycle, JSONL flush, RWMutex, atomic write pattern (temp file, fsync, rename). Knows nothing about entity types. Implements srd002-sqlite-backend R1-R11, R16, srd010-configuration-directories R4-R7."
 
   - path: internal/persistence/mapping/
-    role: "Translation — hydration (SQL row to entity struct) and dehydration (entity struct to SQL params) for all entity types. One mapper per entity type. The only place that knows both field names and column names. Implements prd002-sqlite-backend R14, R15."
+    role: "Translation — hydration (SQL row to entity struct) and dehydration (entity struct to SQL params) for all entity types. One mapper per entity type. The only place that knows both field names and column names. Implements srd002-sqlite-backend R14, R15."
 
   - path: internal/persistence/queryutil/
-    role: "Query helpers — Scanner interface, filter building (AddStringFilter, AddIntFilter), pagination (ApplyLimitOffset), result iteration (FetchRows), and single-row retrieval (GetByID). Entity-agnostic; operates on generic SQL types and callbacks. No dependency on pkg/schema or entity-specific code. Implements prd013-table-query-helpers."
+    role: "Query helpers — Scanner interface, filter building (AddStringFilter, AddIntFilter), pagination (ApplyLimitOffset), result iteration (FetchRows), and single-row retrieval (GetByID). Entity-agnostic; operates on generic SQL types and callbacks. No dependency on pkg/schema or entity-specific code. Implements srd013-table-query-helpers."
 
   - path: internal/persistence/lifecycle/
-    role: "Entity lifecycle — UUID v7 generation with timestamp (NewEntityID), upsert scaffolding (UpsertInTx), and delete scaffolding (DeleteInTx). Entity-agnostic; manages transaction lifecycle and calls entity-specific callbacks. No dependency on pkg/schema or entity-specific code. Implements prd014-entity-lifecycle-helpers."
+    role: "Entity lifecycle — UUID v7 generation with timestamp (NewEntityID), upsert scaffolding (UpsertInTx), and delete scaffolding (DeleteInTx). Entity-agnostic; manages transaction lifecycle and calls entity-specific callbacks. No dependency on pkg/schema or entity-specific code. Implements srd014-entity-lifecycle-helpers."
 
   - path: internal/persistence/
-    role: "Persistence — Table interface implementations for all entity types. One file per entity table (crumbs_table.go, trails_table.go, etc.). Imports pkg/api, pkg/schema, pkg/constants, internal/persistence/engine, mapping, queryutil, and lifecycle. Implements cascade operations for trail complete and abandon. Implements prd002-sqlite-backend R12-R13, prd003-crumbs-interface R6-R10, prd004-properties-interface R4-R6, prd005-metadata-interface R4-R8, prd006-trails-interface R3-R4, prd007-links-interface R3-R4, prd008-stash-interface R3, R8-R11."
+    role: "Persistence — Table interface implementations for all entity types. One file per entity table (crumbs_table.go, trails_table.go, etc.). Imports pkg/api, pkg/schema, pkg/constants, internal/persistence/engine, mapping, queryutil, and lifecycle. Implements cascade operations for trail complete and abandon. Implements srd002-sqlite-backend R12-R13, srd003-crumbs-interface R6-R10, srd004-properties-interface R4-R6, srd005-metadata-interface R4-R8, srd006-trails-interface R3-R4, srd007-links-interface R3-R4, srd008-stash-interface R3, R8-R11."
 
   - path: cmd/cupboard/
-    role: "CLI entrypoint — cobra commands, config loading, output formatting. One file per command group. Imports pkg/api and pkg/schema only; never imports internal/. Implements prd009-cupboard-cli, prd010-configuration-directories R1, R8."
+    role: "CLI entrypoint — cobra commands, config loading, output formatting. One file per command group. Imports pkg/api and pkg/schema only; never imports internal/. Implements srd009-cupboard-cli, srd010-configuration-directories R1, R8."
 
   - path: internal/telemetry/
     role: "Observability — OpenTelemetry traces, metrics, and structured logs. Imported by internal/persistence/engine."
@@ -347,19 +347,19 @@ related_documents:
     purpose: What we are building and why; success criteria and boundaries
   - doc: road-map.yaml
     purpose: Release schedule, use cases, prioritization rules
-  - doc: specs/product-requirements/prd001-cupboard-core.yaml
+  - doc: specs/software-requirements/srd001-cupboard-core.yaml
     purpose: Cupboard interface, configuration, lifecycle
-  - doc: specs/product-requirements/prd002-sqlite-backend.yaml
+  - doc: specs/software-requirements/srd002-sqlite-backend.yaml
     purpose: SQLite backend internals, JSON-to-SQLite sync, graph model
-  - doc: specs/product-requirements/prd003-crumbs-interface.yaml
+  - doc: specs/software-requirements/srd003-crumbs-interface.yaml
     purpose: Crumb entity, state transitions, property methods
-  - doc: specs/product-requirements/prd006-trails-interface.yaml
+  - doc: specs/software-requirements/srd006-trails-interface.yaml
     purpose: Trail entity, lifecycle methods, crumb membership
-  - doc: specs/product-requirements/prd004-properties-interface.yaml
+  - doc: specs/software-requirements/srd004-properties-interface.yaml
     purpose: Property and Category entities, value types
-  - doc: specs/product-requirements/prd005-metadata-interface.yaml
+  - doc: specs/software-requirements/srd005-metadata-interface.yaml
     purpose: Metadata entity, schema registration
-  - doc: specs/product-requirements/prd008-stash-interface.yaml
+  - doc: specs/software-requirements/srd008-stash-interface.yaml
     purpose: Stash entity, shared state, versioning
   - doc: engineering/eng01-git-integration.yaml
     purpose: Git conventions — JSONL always on main, trails vs git branches, commit conventions

--- a/docs/SPECIFICATIONS.yaml
+++ b/docs/SPECIFICATIONS.yaml
@@ -8,7 +8,7 @@ overview: |
   associated crumbs atomically). The system provides a Cupboard interface for backend-agnostic
   storage access and a Table interface for uniform CRUD operations.
 
-  This document indexes all PRDs, use cases, and test suites in the project and shows how they
+  This document indexes all SRDs, use cases, and test suites in the project and shows how they
   relate. For goals and boundaries, see VISION.yaml. For components and interfaces, see
   ARCHITECTURE.yaml.
 
@@ -54,55 +54,55 @@ roadmap_summary:
     use_cases_total: 2
     status: not_started
 
-prd_index:
-  - id: prd001-cupboard-core
+srd_index:
+  - id: srd001-cupboard-core
     title: Cupboard Core Interface
     summary: Defines the Cupboard and Table interfaces for backend-agnostic storage access
-    path: specs/product-requirements/prd001-cupboard-core.yaml
-  - id: prd002-sqlite-backend
+    path: specs/software-requirements/srd001-cupboard-core.yaml
+  - id: srd002-sqlite-backend
     title: SQLite Backend
     summary: Specifies JSONL persistence format, SQLite schema, and startup/write/shutdown sequences
-    path: specs/product-requirements/prd002-sqlite-backend.yaml
-  - id: prd003-crumbs-interface
+    path: specs/software-requirements/srd002-sqlite-backend.yaml
+  - id: srd003-crumbs-interface
     title: Crumbs Interface
     summary: Defines the Crumb entity structure, state transitions, and property operations
-    path: specs/product-requirements/prd003-crumbs-interface.yaml
-  - id: prd004-properties-interface
+    path: specs/software-requirements/srd003-crumbs-interface.yaml
+  - id: srd004-properties-interface
     title: Properties Interface
     summary: Defines Property and Category entities for typed, enumerated crumb attributes
-    path: specs/product-requirements/prd004-properties-interface.yaml
-  - id: prd005-metadata-interface
+    path: specs/software-requirements/srd004-properties-interface.yaml
+  - id: srd005-metadata-interface
     title: Metadata Interface
     summary: Defines the Metadata entity for schema registration and versioning
-    path: specs/product-requirements/prd005-metadata-interface.yaml
-  - id: prd006-trails-interface
+    path: specs/software-requirements/srd005-metadata-interface.yaml
+  - id: srd006-trails-interface
     title: Trails Interface
     summary: Defines the Trail entity for grouping crumbs with Complete/Abandon lifecycle
-    path: specs/product-requirements/prd006-trails-interface.yaml
-  - id: prd007-links-interface
+    path: specs/software-requirements/srd006-trails-interface.yaml
+  - id: srd007-links-interface
     title: Links Interface
     summary: Consolidates link requirements for directed edges in the entity graph
-    path: specs/product-requirements/prd007-links-interface.yaml
-  - id: prd008-stash-interface
+    path: specs/software-requirements/srd007-links-interface.yaml
+  - id: srd008-stash-interface
     title: Stash Interface
     summary: Defines the Stash entity for shared state with content versioning
-    path: specs/product-requirements/prd008-stash-interface.yaml
-  - id: prd009-cupboard-cli
+    path: specs/software-requirements/srd008-stash-interface.yaml
+  - id: srd009-cupboard-cli
     title: Cupboard CLI Interface
     summary: Specifies the command-line interface for cupboard operations
-    path: specs/product-requirements/prd009-cupboard-cli.yaml
-  - id: prd010-configuration-directories
+    path: specs/software-requirements/srd009-cupboard-cli.yaml
+  - id: srd010-configuration-directories
     title: Configuration Directory Structure
     summary: Defines platform-specific configuration and data directory locations for the CLI
-    path: specs/product-requirements/prd010-configuration-directories.yaml
-  - id: prd011-blazes-templates
+    path: specs/software-requirements/srd010-configuration-directories.yaml
+  - id: srd011-blazes-templates
     title: Blazes Template Schema, Discovery, and Selection
     summary: Defines the Blaze template schema for reusable agent workflow patterns with tag-based discovery and selection
-    path: specs/product-requirements/prd011-blazes-templates.yaml
-  - id: prd012-branch-independent-data
+    path: specs/software-requirements/srd011-blazes-templates.yaml
+  - id: srd012-branch-independent-data
     title: Branch-Independent Data Persistence
     summary: Defines that JSONL files always live on main, independent of code branches, decoupling issue lifecycle from git branch lifecycle
-    path: specs/product-requirements/prd012-branch-independent-data.yaml
+    path: specs/software-requirements/srd012-branch-independent-data.yaml
 
 use_case_index:
   - id: rel01.0-uc001-cupboard-lifecycle
@@ -316,299 +316,299 @@ test_suite_index:
     test_case_count: 63
     path: specs/test-suites/test-rel99.0.yaml
 
-prd_to_use_case_mapping:
+srd_to_use_case_mapping:
   - use_case: rel01.0-uc001-cupboard-lifecycle
-    prd: prd001-cupboard-core
+    srd: srd001-cupboard-core
     why_required: Validates Config, Attach, Detach, GetTable contract
     coverage: Partial (R1, R2, R4-R7)
   - use_case: rel01.0-uc002-table-crud
-    prd: prd001-cupboard-core
+    srd: srd001-cupboard-core
     why_required: Uses Cupboard and Table interfaces for CRUD operations
     coverage: Partial (R2)
   - use_case: rel01.0-uc002-table-crud
-    prd: prd002-sqlite-backend
+    srd: srd002-sqlite-backend
     why_required: Exercises UUID generation, hydration, JSONL persistence
     coverage: Partial (R5, R14, R16)
   - use_case: rel01.0-uc003-crumb-lifecycle
-    prd: prd001-cupboard-core
+    srd: srd001-cupboard-core
     why_required: Uses Table interface for persistence and retrieval
     coverage: Partial (R2)
   - use_case: rel01.0-uc003-crumb-lifecycle
-    prd: prd003-crumbs-interface
+    srd: srd003-crumbs-interface
     why_required: Exercises Crumb state machine, creation defaults, filtering
     coverage: Partial (R1-R5, R9, R10)
   - use_case: rel01.0-uc004-scaffolding-validation
-    prd: prd001-cupboard-core
+    srd: srd001-cupboard-core
     why_required: Compile-time verification of Cupboard and Table interfaces
     coverage: Partial (R2, R2.5)
   - use_case: rel01.0-uc004-scaffolding-validation
-    prd: prd002-sqlite-backend
+    srd: srd002-sqlite-backend
     why_required: Verifies NewBackend, Attach, Detach compile
     coverage: Partial
   - use_case: rel01.0-uc004-scaffolding-validation
-    prd: prd003-crumbs-interface
+    srd: srd003-crumbs-interface
     why_required: Compile-time verification of Crumb struct fields
     coverage: Partial (R1)
   - use_case: rel01.0-uc004-scaffolding-validation
-    prd: prd006-trails-interface
+    srd: srd006-trails-interface
     why_required: Compile-time verification of Trail struct
     coverage: Partial
   - use_case: rel01.0-uc004-scaffolding-validation
-    prd: prd004-properties-interface
+    srd: srd004-properties-interface
     why_required: Compile-time verification of Property struct
     coverage: Partial
   - use_case: rel01.0-uc004-scaffolding-validation
-    prd: prd008-stash-interface
+    srd: srd008-stash-interface
     why_required: Compile-time verification of Stash struct
     coverage: Partial
   - use_case: rel01.0-uc004-scaffolding-validation
-    prd: prd005-metadata-interface
+    srd: srd005-metadata-interface
     why_required: Compile-time verification of Metadata struct
     coverage: Partial
   - use_case: rel01.0-uc005-crumbs-table-benchmarks
-    prd: prd001-cupboard-core
+    srd: srd001-cupboard-core
     why_required: Benchmarks Table interface operations at scale
     coverage: Partial (R2, R3)
   - use_case: rel01.0-uc005-crumbs-table-benchmarks
-    prd: prd002-sqlite-backend
+    srd: srd002-sqlite-backend
     why_required: Benchmarks hydration, dehydration, JSONL persistence, index usage
     coverage: Partial (R3.3, R14, R15)
   - use_case: rel01.1-uc001-go-install
-    prd: prd001-cupboard-core
+    srd: srd001-cupboard-core
     why_required: CLI binary uses Config struct and entity types
     coverage: Partial (R1)
   - use_case: rel01.1-uc001-go-install
-    prd: prd002-sqlite-backend
+    srd: srd002-sqlite-backend
     why_required: Backend creates JSONL files and SQLite cache
     coverage: Partial (R1, R4)
   - use_case: rel01.1-uc001-go-install
-    prd: prd010-configuration-directories
+    srd: srd010-configuration-directories
     why_required: Resolves default config and data directories
     coverage: Partial (R1, R2)
   - use_case: rel01.1-uc002-jsonl-git-roundtrip
-    prd: prd002-sqlite-backend
+    srd: srd002-sqlite-backend
     why_required: Validates startup sequence, JSONL source of truth, sync strategies
     coverage: Partial (R1.2, R4, R5.2, R14, R16)
   - use_case: rel01.1-uc002-jsonl-git-roundtrip
-    prd: prd001-cupboard-core
+    srd: srd001-cupboard-core
     why_required: Attach initializes backend
     coverage: Partial (R4)
   - use_case: rel01.1-uc003-configuration-loading
-    prd: prd010-configuration-directories
+    srd: srd010-configuration-directories
     why_required: Validates platform defaults, env overrides, flag overrides, config.yaml lifecycle
     coverage: Partial (R1.2, R1.3, R2.2, R2.3, R7)
   - use_case: rel01.1-uc003-configuration-loading
-    prd: prd009-cupboard-cli
+    srd: srd009-cupboard-cli
     why_required: Tests global flags --config-dir and --data-dir
     coverage: Partial (R6.2, R6.3)
   - use_case: rel01.1-uc004-generic-table-cli
-    prd: prd001-cupboard-core
+    srd: srd001-cupboard-core
     why_required: GetTable returns Table for any standard table name
     coverage: Partial (R2, R3)
   - use_case: rel01.1-uc004-generic-table-cli
-    prd: prd009-cupboard-cli
+    srd: srd009-cupboard-cli
     why_required: Generic get, set, list, delete commands with JSON output
     coverage: Partial (R3.1-R3.4, R7-R9)
   - use_case: rel01.1-uc005-flat-self-hosting
-    prd: prd001-cupboard-core
+    srd: srd001-cupboard-core
     why_required: Uses Cupboard and Table interfaces for crumb storage
     coverage: Partial (R2, R3)
   - use_case: rel01.1-uc005-flat-self-hosting
-    prd: prd009-cupboard-cli
+    srd: srd009-cupboard-cli
     why_required: Generic table commands get, set, list, delete
     coverage: Partial (R3)
   - use_case: rel01.1-uc005-flat-self-hosting
-    prd: prd003-crumbs-interface
+    srd: srd003-crumbs-interface
     why_required: Crumb Name and State fields for basic tracking
     coverage: Partial (R1)
   - use_case: rel01.1-uc005-flat-self-hosting
-    prd: prd002-sqlite-backend
+    srd: srd002-sqlite-backend
     why_required: Storage, JSONL persistence, query engine
     coverage: Partial (R1-R5)
   - use_case: rel02.0-uc001-property-enforcement
-    prd: prd001-cupboard-core
+    srd: srd001-cupboard-core
     why_required: Uses Cupboard and Table interfaces for property storage
     coverage: Partial (R2)
   - use_case: rel02.0-uc001-property-enforcement
-    prd: prd003-crumbs-interface
+    srd: srd003-crumbs-interface
     why_required: Exercises property operations on crumbs
     coverage: Partial (R3, R5)
   - use_case: rel02.0-uc001-property-enforcement
-    prd: prd004-properties-interface
+    srd: srd004-properties-interface
     why_required: Validates property definition, auto-init, backfill, seeding
     coverage: Partial (R2, R4, R7-R9)
   - use_case: rel02.0-uc001-property-enforcement
-    prd: prd002-sqlite-backend
+    srd: srd002-sqlite-backend
     why_required: Property seeding during backend initialization
     coverage: Partial (R9)
   - use_case: rel02.0-uc002-regeneration-compatibility
-    prd: prd002-sqlite-backend
+    srd: srd002-sqlite-backend
     why_required: Validates JSONL format stability across generations
     coverage: Partial (R2, R4, R5, R7.2)
   - use_case: rel02.0-uc002-regeneration-compatibility
-    prd: prd001-cupboard-core
+    srd: srd001-cupboard-core
     why_required: Attach/Detach work identically across generations
     coverage: Partial (R4, R5)
   - use_case: rel02.0-uc002-regeneration-compatibility
-    prd: prd004-properties-interface
+    srd: srd004-properties-interface
     why_required: Property definitions persist across regeneration
     coverage: Partial (R4)
   - use_case: rel02.1-uc001-issue-tracking-cli
-    prd: prd001-cupboard-core
+    srd: srd001-cupboard-core
     why_required: Uses GetTable and Table interface for crumb storage
     coverage: Partial (R2, R3)
   - use_case: rel02.1-uc001-issue-tracking-cli
-    prd: prd003-crumbs-interface
+    srd: srd003-crumbs-interface
     why_required: Exercises creation, state transitions, filtering, properties
     coverage: Partial (R2-R5, R9, R10)
   - use_case: rel02.1-uc001-issue-tracking-cli
-    prd: prd004-properties-interface
+    srd: srd004-properties-interface
     why_required: Uses type, priority, labels properties
     coverage: Partial (R9)
   - use_case: rel02.1-uc001-issue-tracking-cli
-    prd: prd002-sqlite-backend
+    srd: srd002-sqlite-backend
     why_required: JSONL persistence and metadata
     coverage: Partial (R2.8, R5)
   - use_case: rel02.1-uc002-table-benchmarks
-    prd: prd001-cupboard-core
+    srd: srd001-cupboard-core
     why_required: Benchmarks Table interface operations
     coverage: Partial (R3)
   - use_case: rel02.1-uc002-table-benchmarks
-    prd: prd002-sqlite-backend
+    srd: srd002-sqlite-backend
     why_required: Benchmarks hydration, persistence, atomic write, sync, indexes
     coverage: Partial (R3.3, R5.2, R14, R15, R16.2)
   - use_case: rel02.1-uc002-table-benchmarks
-    prd: prd003-crumbs-interface
+    srd: srd003-crumbs-interface
     why_required: Benchmarks property operations and filter queries
     coverage: Partial (R5, R9)
   - use_case: rel02.1-uc003-self-hosting
-    prd: prd001-cupboard-core
+    srd: srd001-cupboard-core
     why_required: Cupboard and Table interfaces for storage
     coverage: Partial (R2, R3)
   - use_case: rel02.1-uc003-self-hosting
-    prd: prd003-crumbs-interface
+    srd: srd003-crumbs-interface
     why_required: Crumb creation, state transitions, filtering
     coverage: Partial (R1, R3, R4, R9, R10)
   - use_case: rel02.1-uc003-self-hosting
-    prd: prd002-sqlite-backend
+    srd: srd002-sqlite-backend
     why_required: Storage, JSONL persistence, query engine
     coverage: Partial (R1-R5, R12-R15)
   - use_case: rel02.1-uc004-metadata-lifecycle
-    prd: prd001-cupboard-core
+    srd: srd001-cupboard-core
     why_required: Uses Cupboard and Table interfaces for metadata storage
     coverage: Partial (R2, R3)
   - use_case: rel02.1-uc004-metadata-lifecycle
-    prd: prd005-metadata-interface
+    srd: srd005-metadata-interface
     why_required: Validates metadata CRUD, schemas, filtering, cascade delete
     coverage: Partial (R1, R3-R7, R10)
   - use_case: rel03.0-uc001-trail-exploration
-    prd: prd006-trails-interface
+    srd: srd006-trails-interface
     why_required: Validates trail creation, completion, abandonment, crumb membership
     coverage: Partial (R3, R5-R7, R9)
   - use_case: rel03.0-uc001-trail-exploration
-    prd: prd002-sqlite-backend
+    srd: srd002-sqlite-backend
     why_required: Link-based querying for trail membership
     coverage: Partial
   - use_case: rel03.0-uc002-link-management
-    prd: prd007-links-interface
+    srd: srd007-links-interface
     why_required: Exercises all four link types and CRUD operations
     coverage: Full
   - use_case: rel03.0-uc002-link-management
-    prd: prd002-sqlite-backend
+    srd: srd002-sqlite-backend
     why_required: Link entity hydration, indexes
     coverage: Partial (R3.3, R14.6)
   - use_case: rel03.0-uc002-link-management
-    prd: prd006-trails-interface
+    srd: srd006-trails-interface
     why_required: belongs_to and branches_from link semantics
     coverage: Partial (R7, R9)
   - use_case: rel03.0-uc002-link-management
-    prd: prd008-stash-interface
+    srd: srd008-stash-interface
     why_required: scoped_to link semantics
     coverage: Partial (R13)
   - use_case: rel03.0-uc003-stash-operations
-    prd: prd001-cupboard-core
+    srd: srd001-cupboard-core
     why_required: Uses Cupboard and Table interfaces for stash storage
     coverage: Partial (R2, R3)
   - use_case: rel03.0-uc003-stash-operations
-    prd: prd008-stash-interface
+    srd: srd008-stash-interface
     why_required: Validates stash types, value ops, counters, locks, history
     coverage: Partial (R1, R2, R4-R7, R9)
   - use_case: rel03.0-uc004-trail-crumb-lifecycle
-    prd: prd001-cupboard-core
+    srd: srd001-cupboard-core
     why_required: Uses Cupboard and Table interfaces for trail, crumb, and link storage
     coverage: Partial (R2, R3)
   - use_case: rel03.0-uc004-trail-crumb-lifecycle
-    prd: prd006-trails-interface
+    srd: srd006-trails-interface
     why_required: Trail lifecycle Complete and Abandon with cascade operations
     coverage: Partial (R2, R5, R6)
   - use_case: rel03.0-uc004-trail-crumb-lifecycle
-    prd: prd007-links-interface
+    srd: srd007-links-interface
     why_required: belongs_to links and cardinality constraints
     coverage: Partial (R2.1, R6.1)
   - use_case: rel03.1-uc001-self-hosting-with-epics
-    prd: prd001-cupboard-core
+    srd: srd001-cupboard-core
     why_required: Uses Cupboard and Table interfaces for trail, crumb, and link storage
     coverage: Partial (R2, R3)
   - use_case: rel03.1-uc001-self-hosting-with-epics
-    prd: prd006-trails-interface
+    srd: srd006-trails-interface
     why_required: Trail lifecycle for epic-style grouping
     coverage: Partial (R2, R5, R6)
   - use_case: rel03.1-uc001-self-hosting-with-epics
-    prd: prd007-links-interface
+    srd: srd007-links-interface
     why_required: belongs_to links associate crumbs with trails
     coverage: Partial (R2.1)
   - use_case: rel03.1-uc001-self-hosting-with-epics
-    prd: prd002-sqlite-backend
+    srd: srd002-sqlite-backend
     why_required: Storage, JSONL persistence for trails and links
     coverage: Partial (R1-R5)
   - use_case: rel99.0-uc001-blazes-templates
-    prd: prd011-blazes-templates
+    srd: srd011-blazes-templates
     why_required: Template schema, discovery, tag matching, and selection
     coverage: Partial (R1, R4-R8)
   - use_case: rel99.0-uc001-blazes-templates
-    prd: prd003-crumbs-interface
+    srd: srd003-crumbs-interface
     why_required: Crumb struct fields referenced in template definitions
     coverage: Partial (R1)
   - use_case: rel99.0-uc001-blazes-templates
-    prd: prd006-trails-interface
+    srd: srd006-trails-interface
     why_required: Trail creation and belongs_to links for instantiation
     coverage: Partial (R3, R7)
   - use_case: rel99.0-uc002-docker-bootstrap
-    prd: prd001-cupboard-core
+    srd: srd001-cupboard-core
     why_required: Core storage abstraction with Attach/Detach lifecycle
     coverage: Partial (R1-R3)
   - use_case: rel99.0-uc002-docker-bootstrap
-    prd: prd002-sqlite-backend
+    srd: srd002-sqlite-backend
     why_required: Storage implementation with JSONL source of truth
     coverage: Partial (R1-R16)
   - use_case: rel99.0-uc002-docker-bootstrap
-    prd: prd003-crumbs-interface
+    srd: srd003-crumbs-interface
     why_required: Work item with state lifecycle and properties
     coverage: Partial (R1-R11)
   - use_case: rel99.0-uc002-docker-bootstrap
-    prd: prd010-configuration-directories
+    srd: srd010-configuration-directories
     why_required: Config and data directory paths, JSONL format
     coverage: Partial (R3, R4, R7, R8)
   - use_case: rel04.0-uc001-branch-independent-data
-    prd: prd012-branch-independent-data
+    srd: srd012-branch-independent-data
     why_required: Validates that JSONL lives on main, issue state is branch-independent, and branch abandonment does not affect issues
     coverage: Full (R1-R4)
   - use_case: rel04.0-uc001-branch-independent-data
-    prd: prd002-sqlite-backend
+    srd: srd002-sqlite-backend
     why_required: SQLite rebuilt from JSONL on Attach; cupboard.db gitignored
     coverage: Partial (R1.1, R4)
   - use_case: rel04.0-uc001-branch-independent-data
-    prd: prd010-configuration-directories
+    srd: srd010-configuration-directories
     why_required: Data directory path resolved from configuration, not from branch name
     coverage: Partial (R1, R2)
 
 coverage_gaps: |
-  No traceability gaps. All 24 use cases have corresponding test suites, and all 12 PRDs are
+  No traceability gaps. All 24 use cases have corresponding test suites, and all 12 SRDs are
   referenced by at least one use case.
 
-  prd012-branch-independent-data is covered by rel04.0-uc001-branch-independent-data.
+  srd012-branch-independent-data is covered by rel04.0-uc001-branch-independent-data.
   Implementation for rel04.0 has not started.
 
-  mage analyze reports that 9 core PRDs span multiple releases (e.g., prd001-cupboard-core,
-  prd002-sqlite-backend). This is by design: foundational PRDs underpin every release and
+  mage analyze reports that 9 core SRDs span multiple releases (e.g., srd001-cupboard-core,
+  srd002-sqlite-backend). This is by design: foundational SRDs underpin every release and
   are intentionally reused across the roadmap. The warning is informational, not a gap.

--- a/docs/VISION.yaml
+++ b/docs/VISION.yaml
@@ -113,7 +113,7 @@ risks:
   - risk: Backend proliferation without clear interface boundary
     impact: High
     likelihood: Low
-    mitigation: The Cupboard interface is the single contract all backends implement. prd001-cupboard-core defines this contract precisely. Non-standard extensions must not appear in the interface.
+    mitigation: The Cupboard interface is the single contract all backends implement. srd001-cupboard-core defines this contract precisely. Non-standard extensions must not appear in the interface.
   - risk: Property schema complexity outpacing the enforcement mechanism
     impact: Medium
     likelihood: Medium

--- a/docs/constitutions/design.yaml
+++ b/docs/constitutions/design.yaml
@@ -1,7 +1,7 @@
 # Design Constitution
 #
 # This constitution governs the design/architecting phase: creating VISION,
-# ARCHITECTURE, PRDs, use cases, test suites, and other documentation. It is
+# ARCHITECTURE, SRDs, use cases, test suites, and other documentation. It is
 # scaffolded into consuming projects so Claude knows how to write specs that
 # match the project's documentation standards.
 
@@ -10,13 +10,13 @@ articles:
     title: Specification-driven development
     rule: |
       Specifications are the source of truth. Code serves specifications, not
-      the other way around. No implementation code before the PRD and use case
+      the other way around. No implementation code before the SRD and use case
       exist. No implementation issue before a test suite exists for its use case.
 
   - id: D2
     title: YAML-first for structured docs
     rule: |
-      Use YAML for structured documents (VISION, ARCHITECTURE, PRDs, use cases,
+      Use YAML for structured documents (VISION, ARCHITECTURE, SRDs, use cases,
       test suites). Use markdown for prose-heavy guidelines and specifications
       summaries. YAML is machine-readable by design.
 
@@ -30,9 +30,9 @@ articles:
   - id: D4
     title: Traceability
     rule: |
-      Every PRD traces to VISION and ARCHITECTURE. Every use case traces to
-      PRDs (via touchpoints). Every test suite traces to use cases (via the
-      traces field). Code traces to PRDs via commit messages and comments.
+      Every SRD traces to VISION and ARCHITECTURE. Every use case traces to
+      SRDs (via touchpoints). Every test suite traces to use cases (via the
+      traces field). Code traces to SRDs via commit messages and comments.
 
   - id: D5
     title: Roadmap-driven releases
@@ -97,7 +97,7 @@ document_types:
     purpose: |
       States what the project is, why it exists, how success is measured, and
       what it is not. Orients stakeholders, new contributors, and downstream
-      docs (ARCHITECTURE, PRDs).
+      docs (ARCHITECTURE, SRDs).
 
   architecture:
     location: docs/ARCHITECTURE.yaml
@@ -116,11 +116,11 @@ document_types:
     purpose: |
       Describes how the system is built: components, interfaces, protocols,
       data flow, design decisions. Bridge between vision (what and why) and
-      PRDs (numbered requirements).
+      SRDs (numbered requirements).
 
-  prd:
-    location: "docs/specs/product-requirements/prd[NNN]-[feature-name].yaml"
-    format_rule: prd-format
+  srd:
+    location: "docs/specs/software-requirements/srd[NNN]-[feature-name].yaml"
+    format_rule: srd-format
     required_fields:
       - id
       - title
@@ -147,12 +147,12 @@ document_types:
           - R6.1:
               text: Must scan each input line for known timestamp patterns
               weight: 3
-      acceptance_criteria_ids: "AC1, AC2, AC3, ... (sequential within each PRD)"
+      acceptance_criteria_ids: "AC1, AC2, AC3, ... (sequential within each SRD)"
     acceptance_criteria_schema:
       description: |
         Each acceptance criterion is a structured object linking a checkable
         statement to the requirement items it validates. Every R-item in the
-        PRD must appear in at least one AC's traces list.
+        SRD must appear in at least one AC's traces list.
       fields:
         - id: "AC1, AC2, ... (sequential)"
         - criterion: "Checkable statement (the prose text)"
@@ -188,18 +188,18 @@ document_types:
     success_criteria_schema:
       description: |
         Each success criterion is a structured object linking a checkable
-        outcome to the PRD acceptance criteria it exercises. The traces field
-        references PRD AC IDs using the format prdNNN-name ACN.
+        outcome to the SRD acceptance criteria it exercises. The traces field
+        references SRD AC IDs using the format srdNNN-name ACN.
       fields:
         - id: "S1, S2, ... (sequential)"
         - criterion: "Checkable outcome statement"
-        - traces: "List of PRD AC IDs (e.g., [prd001-orchestrator-core AC1])"
+        - traces: "List of SRD AC IDs (e.g., [srd001-orchestrator-core AC1])"
       example: |
         success_criteria:
           - id: S1
             criterion: New(config) returns a non-nil *Orchestrator
             traces:
-              - prd001-orchestrator-core AC2
+              - srd001-orchestrator-core AC2
     purpose: |
       Describes a concrete usage of the architecture. One end-to-end path
       (tracer bullet) through the system. Leads to a proof-of-concept or demo.
@@ -216,8 +216,8 @@ document_types:
       - test_cases (list organized by use case sub-sections, each with name, inputs, expected outputs)
     traces_format: |
       The traces field in test_cases can reference three kinds of IDs:
-        - PRD R-item IDs: prdNNN-name RN.N (e.g., prd001-orchestrator-core R1.1)
-        - PRD AC IDs: prdNNN-name ACN (e.g., prd001-orchestrator-core AC1)
+        - SRD R-item IDs: srdNNN-name RN.N (e.g., srd001-orchestrator-core R1.1)
+        - SRD AC IDs: srdNNN-name ACN (e.g., srd001-orchestrator-core AC1)
         - UC S-item IDs: relNN.N-ucNNN-name SN (e.g., rel01.0-uc001-orchestrator-initialization S1)
     purpose: |
       Groups test cases for a full release. Each use case in the release appears
@@ -238,8 +238,28 @@ document_types:
       - references
     purpose: |
       Documents conventions, practices, and patterns above the code and
-      architecture. Not PRDs (no numbered requirements). Not architecture (no
+      architecture. Not SRDs (no numbered requirements). Not architecture (no
       component descriptions).
+
+  interface_specification:
+    location: "docs/interfaces/ifc-[kebab-case-name].yaml"
+    format_rule: interface-specification-format
+    required_fields:
+      - id (matches filename without extension)
+      - name (must match ARCHITECTURE.yaml interface entry)
+      - summary (one to three sentences)
+    optional_fields:
+      - "data_structures (list: name, description, fields as typed field list)"
+      - "operations (list: name, description, parameters, returns)"
+      - announcements (list of events the interface emits)
+      - references (list of SRD or use case IDs)
+    purpose: |
+      Standalone, language-agnostic interface contract. Uses typed field
+      lists for data structures and typed parameter/return lists for
+      operations. Pure YAML throughout, consistent with D2. Replaces
+      Go-specific signatures inlined in ARCHITECTURE.yaml with
+      machine-parseable definitions. See eng10-interface-specifications for
+      the full format and examples.
 
   specification:
     location: docs/SPECIFICATIONS.yaml
@@ -249,16 +269,16 @@ document_types:
       - title
       - overview (multi-line text)
       - "roadmap_summary (list: version, name, use_cases_done, use_cases_total, status)"
-      - "prd_index (list: id, title, summary, path)"
+      - "srd_index (list: id, title, summary, path)"
       - "use_case_index (list: id, title, release, status, test_suite, path)"
       - "test_suite_index (list: id, title, traces, test_case_count, path)"
-      - "prd_to_use_case_mapping (list: use_case, prd, why_required, coverage)"
+      - "srd_to_use_case_mapping (list: use_case, srd, why_required, coverage)"
       - coverage_gaps (list or multi-line text)
     optional_fields:
       - traceability_diagram (Mermaid as multi-line string)
       - references
     purpose: |
-      Human-readable summary tying together PRDs, use cases, test suites, and
+      Human-readable summary tying together SRDs, use cases, test suites, and
       roadmap into one navigable page. Does not duplicate content; summarizes
       and shows relationships. Regenerate when any artifact changes.
 
@@ -300,10 +320,11 @@ document_types:
       Do not estimate; read the files.
 
 naming_conventions:
-  prd: "prd[NNN]-[feature-name].yaml (e.g., prd001-cupboard-core.yaml)"
+  srd: "srd[NNN]-[feature-name].yaml (e.g., srd001-cupboard-core.yaml)"
   use_case: "rel[NN].[N]-uc[NNN]-[short-name].yaml (e.g., rel01.0-uc001-cupboard-lifecycle.yaml)"
   test_suite: "test-[use-case-id].yaml (e.g., test-rel01.0-uc001-cupboard-lifecycle.yaml)"
   engineering_guideline: "eng[NN]-[short-name].yaml (e.g., eng01-git-integration.yaml)"
+  interface_specification: "ifc-[kebab-case-name].yaml (e.g., ifc-generation-lifecycle.yaml)"
   architecture: "ARCHITECTURE.yaml"
   vision: "VISION.yaml"
   specification: "SPECIFICATIONS.yaml"
@@ -318,10 +339,10 @@ writing_guidelines:
 traceability_model:
   vision: Goals and boundaries
   architecture: Components and interfaces (implements vision)
-  prds: Numbered requirements (architecture points to PRDs for detail)
+  srds: Numbered requirements (architecture points to SRDs for detail)
   use_cases: Tracer bullets (exercise architecture components via touchpoints)
   test_suites: Validation (validate use case success criteria)
-  code: Implementation (traces to PRDs via commit messages)
+  code: Implementation (traces to SRDs via commit messages)
 
 completeness_checklists:
   vision:
@@ -337,13 +358,13 @@ completeness_checklists:
   architecture:
     - id matches project name
     - overview.summary states what the system does and core insight
-    - interfaces list data structures, operations, announcements; link to PRD for full spec
-    - components list each major component with responsibility; link to PRD or use case
+    - interfaces list data structures, operations, announcements; link to SRD for full spec
+    - components list each major component with responsibility; link to SRD or use case
     - design_decisions are numbered with decision statement and benefits
     - project_structure shows directory paths and roles
     - File saved as ARCHITECTURE.yaml in docs/
 
-  prd:
+  srd:
     - id matches filename without extension
     - problem states what we solve and why it matters
     - goals are numbered (G1, G2, ...) and measurable
@@ -353,13 +374,14 @@ completeness_checklists:
     - acceptance_criteria are structured objects with id, criterion, and traces
     - Every R-item appears in at least one AC's traces list
     - Interactive requirements (prompting, confirmation) specify exact prompt text, accepted input values, case sensitivity, retry behavior on invalid input, and default behavior when stdin is not a terminal
-    - File saved as prd[NNN]-[feature-name].yaml
+    - File saved as srd[NNN]-[feature-name].yaml
 
   use_case:
     - id matches filename without extension
     - flow steps are numbered (F1, F2, ...), end-to-end, map to real components
     - touchpoints are numbered (T1, T2, ...) and list interfaces, components, protocols
-    - success_criteria are structured objects with id, criterion, and traces to PRD AC IDs
+    - touchpoints that cite SRDs must include R-group references (e.g., "srd030-md5sum R1, R2, R3"); bare SRD citations without R-groups break codereadiness computation
+    - success_criteria are structured objects with id, criterion, and traces to SRD AC IDs
     - test_suite references a corresponding test suite ID
     - Test suite YAML exists and traces back to this use case
     - Use case added to appropriate release in road-map.yaml
@@ -367,12 +389,21 @@ completeness_checklists:
 
   test_suite:
     - id matches filename
-    - traces lists at least one use case or PRD requirement
+    - traces lists at least one use case or SRD requirement
     - preconditions describe shared starting state
     - Each test case has name, inputs, expected outputs
     - Inputs use real commands and data
     - Expected outputs are specific and checkable
     - File saved as test-[use-case-id].yaml
+
+  interface_specification:
+    - id matches filename without extension (ifc-[kebab-case-name])
+    - name matches the corresponding ARCHITECTURE.yaml interface entry
+    - summary describes the interface contract in one to three sentences
+    - data_structures use typed field lists (name, type, description, required)
+    - operations have name, description, typed parameters, and typed returns
+    - references list SRD or use case IDs the interface traces to
+    - File saved as ifc-[kebab-case-name].yaml in docs/interfaces/
 
 sections:
   - tag: articles
@@ -391,14 +422,15 @@ sections:
   - tag: document_types
     title: Document Types
     content: |
-      Seven document types are defined: vision, architecture, PRD, use case,
-      test suite, engineering guideline, and specification. Each has a canonical
-      location, format rule, required fields, and optional fields.
+      Eight document types are defined: vision, architecture, SRD, use case,
+      test suite, engineering guideline, interface specification, and
+      specification. Each has a canonical location, format rule, required
+      fields, and optional fields.
   - tag: naming_conventions
     title: Naming Conventions
     content: |
       File names follow strict patterns per document type (e.g.,
-      prd[NNN]-[feature].yaml, rel[NN].[N]-uc[NNN]-[name].yaml). Use lowercase
+      srd[NNN]-[feature].yaml, rel[NN].[N]-uc[NNN]-[name].yaml). Use lowercase
       kebab-case throughout.
   - tag: writing_guidelines
     title: Writing Guidelines
@@ -410,7 +442,7 @@ sections:
     title: Traceability Model
     content: |
       Every artifact traces through the chain: vision goals → architecture
-      components → PRD requirements → use case tracer bullets → test suite
+      components → SRD requirements → use case tracer bullets → test suite
       validation → code implementation.
   - tag: completeness_checklists
     title: Completeness Checklists

--- a/docs/constitutions/execution.yaml
+++ b/docs/constitutions/execution.yaml
@@ -8,16 +8,16 @@ articles:
   - id: E1
     title: Specification-first
     rule: |
-      Code must correspond to existing PRDs and architecture. Read the PRDs and
+      Code must correspond to existing SRDs and architecture. Read the SRDs and
       ARCHITECTURE sections listed in Required Reading before writing code. Do
       not invent interfaces, types, or patterns not described in those docs.
 
   - id: E2
     title: Traceability
     rule: |
-      Commit messages must mention which PRDs (or aspects) are implemented.
-      Example: "Implement X (prd-feature-name R6-R7)". Where useful (package or
-      top-of-file comments), list the implemented PRDs.
+      Commit messages must mention which SRDs (or aspects) are implemented.
+      Example: "Implement X (srd-feature-name R6-R7)". Where useful (package or
+      top-of-file comments), list the implemented SRDs.
 
   - id: E3
     title: No scope creep
@@ -43,7 +43,7 @@ articles:
   - id: E6
     title: Non-goals enforcement
     rule: |
-      Features listed in a PRD's non_goals must not be implemented. Do not
+      Features listed in a SRD's non_goals must not be implemented. Do not
       parse, accept, or act on flags, options, or behaviors that appear in
       non_goals. If a requirement references a non_goal feature, treat it as
       a specification error and skip the requirement with a TODO comment
@@ -137,7 +137,7 @@ coding_standards:
     tests/: Integration tests.
     magefiles/: Build tooling. Flat directory. One file per concern.
 
-    Align package structure to PRD component structure. Each major component
+    Align package structure to SRD component structure. Each major component
     maps to one package. Avoid package names like util, common, helpers.
 
   standard_packages:
@@ -168,23 +168,23 @@ coding_standards:
 
 traceability:
   before_implementing:
-    - Identify related PRDs, ARCHITECTURE, use cases, test suites, guidelines, VISION
+    - Identify related SRDs, ARCHITECTURE, use cases, test suites, guidelines, VISION
     - Read the relevant sections so behavior, data shapes, and contracts are clear
     - Implement so the code conforms to the requirements and design described
 
   commit_message: |
-    Must mention which PRDs (or aspects) are being implemented. Prefer explicit:
-    "Implement X (prd-feature-name, prd-component)" or "Add Y per prd-feature R12".
-    If only parts touched, say so: "Implement operation X (prd-feature R8, R13)".
+    Must mention which SRDs (or aspects) are being implemented. Prefer explicit:
+    "Implement X (srd-feature-name, srd-component)" or "Add Y per srd-feature R12".
+    If only parts touched, say so: "Implement operation X (srd-feature R8, R13)".
 
   code_comments: |
-    At the top of a file or package doc, list implemented PRDs and architecture
+    At the top of a file or package doc, list implemented SRDs and architecture
     sections. Do not repeat this in every function; use file- or package-level
     comments only.
 
   reference_paths:
     - "Architecture: docs/ARCHITECTURE.yaml"
-    - "PRDs: docs/specs/product-requirements/prd*.yaml"
+    - "SRDs: docs/specs/software-requirements/srd*.yaml"
     - "Use cases: docs/specs/use-cases/rel*-uc*-*.yaml"
     - "Test suites (YAML specs): docs/specs/test-suites/test-rel-*.yaml"
     - "Release tests (Go): tests/rel-*/rel-*_test.go"
@@ -268,8 +268,8 @@ sections:
   - tag: traceability
     title: Traceability
     content: |
-      Before implementing, read the specified PRDs and architecture sections.
-      Commit messages must cite PRDs. Add a PRD list to file or package comments
+      Before implementing, read the specified SRDs and architecture sections.
+      Commit messages must cite SRDs. Add a SRD list to file or package comments
       where useful.
   - tag: session_completion
     title: Session Completion

--- a/docs/constitutions/go-style.yaml
+++ b/docs/constitutions/go-style.yaml
@@ -26,6 +26,28 @@ duplication: |
   share fields. Use helper functions to share behavior. Use interfaces to share
   contracts. The threshold is two: if you write the same thing twice, extract it.
 
+implementation_strategy: |
+  Write all source files before running any build or test commands. Plan the
+  full implementation (types, functions, imports) mentally, then write each
+  file in dependency order. Only run `go build` or `go vet` after all files
+  are written. This minimizes turns and avoids incremental compile-fix loops
+  that re-send the entire prompt context on each iteration.
+
+  When writing a new cmd/ utility:
+  1. Read the SRD and existing pkg/ contracts.
+  2. Write main.go with all flag parsing, logic, and error handling in one pass.
+  3. Write the test file with all test cases in one pass.
+  4. Run `go vet` once to verify compilation.
+  5. Run `go test` once to verify behavior.
+  6. Fix any issues in a single edit pass.
+
+  Common Go compilation errors to avoid on first write:
+  - Missing imports: always include fmt, os, io, strings when doing I/O.
+  - Unused imports: do not import packages speculatively.
+  - Type mismatches: check pkg/ contract signatures before calling.
+  - Missing error handling: every function that returns error must be checked.
+  - Unused variables: do not declare variables before they are needed.
+
 design_patterns:
   - name: Strategy
     description: |
@@ -208,7 +230,7 @@ project_structure: |
   enforced by Go's internal/ directory convention. This rule applies uniformly to
   packages under pkg/ and to top-level internal/ packages alike.
 
-  Align package structure to PRD component structure. Each major component maps
+  Align package structure to SRD component structure. Each major component maps
   to one package. Avoid package names like util, common, helpers. Name packages
   by domain: storage, auth, config.
 
@@ -362,6 +384,7 @@ code_review_checklist:
   - "No init() function performs I/O or returns an error."
   - "No panic() is reachable from a runtime condition or user-provided input."
   - "Typed iota enums are used for any fixed set of integer values."
+  - "All source files are written before running build or test commands — no incremental compile-fix loops."
 
 sections:
   - tag: copyright_header
@@ -374,6 +397,13 @@ sections:
       Search for existing code before writing a new function. Extract shared
       logic at the two-occurrence threshold — if you write the same thing twice,
       extract it.
+  - tag: implementation_strategy
+    title: Implementation Strategy
+    content: |
+      Write all source files before running any build or test commands. Plan
+      the full implementation, write each file in dependency order, then
+      compile and test once. This avoids incremental compile-fix loops that
+      waste turns re-sending the entire prompt context.
   - tag: design_patterns
     title: Design Patterns
     content: |

--- a/docs/constitutions/interface.yaml
+++ b/docs/constitutions/interface.yaml
@@ -1,0 +1,135 @@
+# Interface Constitution
+#
+# This constitution governs the definition, naming, and traceability of
+# interfaces in the architecture and SRDs. It is scaffolded into consuming
+# projects so Claude knows how to write well-formed interface specifications
+# and how SRDs reference interfaces.
+
+articles:
+  - id: I1
+    title: Interface specifications live in docs/interfaces/
+    rule: |
+      Every interface has a specification file in docs/interfaces/. The
+      specification file is the authoritative contract: it defines data
+      structures with typed fields and operations with typed parameters and
+      return values. See eng10-interface-specifications for the full format.
+
+      ARCHITECTURE.yaml declares each interface in its interfaces section
+      with a name, summary, and a spec_file field pointing to the
+      specification file. The ARCHITECTURE.yaml entry is a discovery point
+      and summary; the specification file is the source of truth.
+
+  - id: I2
+    title: Required interface fields
+    rule: |
+      Every interface entry in ARCHITECTURE.yaml must have a name, a
+      summary, and a spec_file. The name is a short, unique identifier
+      (e.g., "Orchestrator and Config", "Prompt Templates"). The summary
+      describes what the interface provides in one to three sentences. The
+      spec_file is the path to the specification file in docs/interfaces/.
+      Optional fields are data_structures (list of type names with brief
+      descriptions) and operations (list of method or function signatures).
+
+      Interface specification files in docs/interfaces/ must have id, name,
+      and summary. Optional fields are data_structures (with typed field
+      lists), operations (with typed parameters and returns), announcements,
+      and references.
+
+  - id: I3
+    title: Naming conventions
+    rule: |
+      Interface names use title case with spaces (e.g., "Generation
+      Lifecycle", "Issue Tracker"). Names must be unique within
+      ARCHITECTURE.yaml. Abbreviations are permitted when the abbreviation
+      is standard in the domain (e.g., "OOD" for object-oriented design),
+      but must be explained in the summary on first use.
+
+      Specification file names use kebab case matching the interface name:
+      ifc-[kebab-case-name].yaml (e.g., ifc-generation-lifecycle.yaml).
+
+  - id: I4
+    title: SRD interface references
+    rule: |
+      SRDs may declare interface relationships using two optional fields:
+      implemented_by and used_by. Both are lists of interface names that
+      must resolve to entries in ARCHITECTURE.yaml's interfaces section.
+
+      implemented_by declares that the SRD's requirements define the
+      implementation of the named interface. The SRD's package_contract
+      exports correspond to the interface's operations.
+
+      used_by declares that the SRD's implementation consumes the named
+      interface. The SRD depends on the interface being available but does
+      not define it.
+
+      A single SRD may appear in both lists for different interfaces. An
+      interface may be implemented by one SRD and used by many.
+
+  - id: I5
+    title: Port and adapter semantics
+    rule: |
+      Interfaces follow the ports and adapters pattern. The specification
+      file in docs/interfaces/ is the port: it defines the contract without
+      specifying implementation. ARCHITECTURE.yaml is the discovery index
+      that points to ports via spec_file. SRDs that list the interface in
+      implemented_by are adapters: they provide a concrete implementation
+      of the port.
+
+      This separation means changing an adapter (rewriting a SRD's
+      implementation) does not change the port (the specification file).
+      Consumers that reference the interface via used_by depend on the
+      port, not the adapter. Analysis enforces that every referenced
+      interface name resolves to a declared port.
+
+      The port contract is defined in the specification file using typed
+      field lists for data structures and typed parameter/return lists for
+      operations.
+
+  - id: I6
+    title: Interface traceability
+    rule: |
+      The traceability chain for interfaces runs: ARCHITECTURE.yaml
+      (declares the interface with spec_file) -> specification file in
+      docs/interfaces/ (defines the contract) -> SRD implemented_by
+      (provides the implementation) -> SRD used_by (consumes the
+      interface). Analysis validates both directions: every name in
+      implemented_by and used_by must match an interface name in
+      ARCHITECTURE.yaml. Broken references fail the analysis check.
+
+      Specification files include a references field listing SRD and use
+      case IDs that the interface traces to, completing the bidirectional
+      link.
+
+sections:
+  - tag: articles
+    title: Core Principles
+    content: |
+      Six principles govern interface specifications: interfaces live in
+      docs/interfaces/ as standalone specification files referenced from
+      ARCHITECTURE.yaml via spec_file (I1), required ARCHITECTURE.yaml
+      fields are name, summary, and spec_file (I2), names use title case
+      and specification files use kebab case (I3), SRDs reference
+      interfaces via implemented_by and used_by (I4), specification files
+      are the ports in ports-and-adapters semantics (I5), and traceability
+      runs from architecture through specification files through SRDs (I6).
+  - tag: structure
+    title: Interface Structure
+    content: |
+      An interface entry in ARCHITECTURE.yaml is a YAML mapping with five
+      fields: name (required), summary (required), spec_file (required),
+      data_structures (optional list), and operations (optional list). SRDs
+      reference interfaces by name using implemented_by and used_by string
+      lists.
+
+      Specification files in docs/interfaces/ use typed field lists for
+      data structures and typed parameter/return lists for operations.
+      See eng10-interface-specifications for the full format.
+  - tag: validation
+    title: Analysis Validation
+    content: |
+      The mage analyze target validates interface references. Every entry
+      in a SRD's implemented_by and used_by lists must match the name
+      field of an interface in ARCHITECTURE.yaml. Unresolved references
+      are reported as errors. Missing or empty interface lists are not
+      errors; the fields are optional. Analyze validates that spec_file
+      paths point to existing files.

--- a/docs/constitutions/planning.yaml
+++ b/docs/constitutions/planning.yaml
@@ -56,29 +56,29 @@ articles:
   - id: P5
     title: Dependency ordering
     rule: |
-      Identify what should be built first and why. PRDs before use cases,
+      Identify what should be built first and why. SRDs before use cases,
       use cases before test suites, test suites before code, foundational code
       before features, libraries before CLI.
 
   - id: P6
     title: Requirement-anchored decomposition
     rule: |
-      Anchor each task to specific PRD requirements by ID (e.g., prd001 R1.1,
-      prd002 R2.3). Include the requirement ID(s) in the task title. Each PRD
+      Anchor each task to specific SRD requirements by ID (e.g., srd001 R1.1,
+      srd002 R2.3). Include the requirement ID(s) in the task title. Each SRD
       requirement maps to exactly one task unless the requirement exceeds the
       line budget, in which case split into implementation and test tasks that
       both reference the same requirement. Do not invent task boundaries that
       cross requirement boundaries. This makes decomposition deterministic:
-      given the same PRD and release, the same set of tasks should be proposed.
+      given the same SRD and release, the same set of tasks should be proposed.
 
   - id: P7
     title: File naming conventions
     rule: |
       Derive file names from the module or feature name established in the
-      PRD or architecture document. Use the existing project naming pattern
+      SRD or architecture document. Use the existing project naming pattern
       (snake_case for Go files, kebab-case for YAML documents). When creating
       a new package, use the name from ARCHITECTURE.yaml. Do not invent novel
-      file names. If the PRD names a component "crumb", the file is crumb.go,
+      file names. If the SRD names a component "crumb", the file is crumb.go,
       not item.go or entity.go. Go packages must name the primary source file
       after the primary exported type, not the package name.
       `testutils/testutils.go` is forbidden; if the primary type is
@@ -102,7 +102,7 @@ articles:
     rule: |
       Code tasks target 5-8 requirements, 5-8 acceptance criteria, and 3-5
       design decisions. Documentation tasks target 2-4 requirements and 3-5
-      acceptance criteria. Each PRD requirement maps to exactly one task
+      acceptance criteria. Each SRD requirement maps to exactly one task
       requirement. Do not inflate counts by splitting a single requirement
       into sub-bullets, and do not deflate counts by merging unrelated
       requirements. If a task falls outside these ranges, re-examine the
@@ -118,7 +118,7 @@ issue_structure:
     required_reading:
       required: true
       description: |
-        Files the agent must read before starting. List PRDs, ARCHITECTURE
+        Files the agent must read before starting. List SRDs, ARCHITECTURE
         sections, existing code, or upstream docs. This is mandatory for all
         issues.
 
@@ -153,7 +153,7 @@ issue_structure:
       format_rule:
         required: true
         description: |
-          The rule file that governs the output format (e.g., prd-format,
+          The rule file that governs the output format (e.g., srd-format,
           use-case-format, test-case-format, architecture-format,
           vision-format, specification-format, engineering-guideline-format).
 
@@ -161,7 +161,7 @@ issue_structure:
         required: false
         description: |
           List of sections the document must contain, per the format rule.
-          For PRD: Problem, Goals, Requirements, Non-Goals, Acceptance Criteria.
+          For SRD: Problem, Goals, Requirements, Non-Goals, Acceptance Criteria.
           For use case: Summary, Actor/trigger, Flow, Success criteria.
 
     deliverable_types:
@@ -170,9 +170,9 @@ issue_structure:
         format_rule: architecture-format
         when: Updating system overview, components, design decisions
 
-      - type: PRD
-        location: "docs/specs/product-requirements/prd[NNN]-[feature-name].yaml"
-        format_rule: prd-format
+      - type: SRD
+        location: "docs/specs/software-requirements/srd[NNN]-[feature-name].yaml"
+        format_rule: srd-format
         when: New or updated product requirements
 
       - type: Use case
@@ -193,7 +193,7 @@ issue_structure:
       - type: Specification
         location: docs/SPECIFICATIONS.md
         format_rule: specification-format
-        when: Summary of PRDs, use cases, test suites, roadmap
+        when: Summary of SRDs, use cases, test suites, roadmap
 
   yaml_quality:
     - Use ASCII dashes (--), not Unicode em dashes or en dashes.
@@ -201,21 +201,21 @@ issue_structure:
 
   code_issues:
     rules:
-      - No PRD-style Problem/Goals/Non-Goals sections in code issues
+      - No SRD-style Problem/Goals/Non-Goals sections in code issues
       - "Requirements focus on implementation: interfaces, operations, tests"
-      - Design decisions reference PRDs and architecture patterns
+      - Design decisions reference SRDs and architecture patterns
       - Acceptance criteria include tests passing and behavior verified
 
 example_documentation_issue: |
   deliverable_type: documentation
-  format_rule: prd-format
+  format_rule: srd-format
 
   required_reading:
     - docs/ARCHITECTURE.yaml (components section)
-    - docs/specs/product-requirements/prd001-cupboard-core.yaml
+    - docs/specs/software-requirements/srd001-cupboard-core.yaml
 
   files:
-    - path: docs/specs/product-requirements/prd-feature-name.yaml
+    - path: docs/specs/software-requirements/srd-feature-name.yaml
       action: create
 
   required_sections:
@@ -229,7 +229,7 @@ example_documentation_issue: |
     - id: AC1
       text: All required sections present
     - id: AC2
-      text: File saved as prd-feature-name.yaml
+      text: File saved as srd-feature-name.yaml
     - id: AC3
       text: Requirements numbered and specific
 
@@ -237,7 +237,7 @@ example_code_issue: |
   deliverable_type: code
 
   required_reading:
-    - docs/specs/product-requirements/prd003-crumbs-interface.yaml
+    - docs/specs/software-requirements/srd003-crumbs-interface.yaml
     - pkg/types/cupboard.go
 
   files:
@@ -253,7 +253,7 @@ example_code_issue: |
 
   requirements:
     - id: R1
-      text: Implement CrumbTable interface per prd003-crumbs-interface
+      text: Implement CrumbTable interface per srd003-crumbs-interface
     - id: R2
       text: Add, Get, Archive, Purge, Fetch operations
     - id: R3
@@ -261,9 +261,9 @@ example_code_issue: |
 
   design_decisions:
     - id: D1
-      text: Use table accessor pattern from prd001-cupboard-core
+      text: Use table accessor pattern from srd001-cupboard-core
     - id: D2
-      text: Filter as map[string]any per PRD
+      text: Filter as map[string]any per SRD
 
   acceptance_criteria:
     - id: AC1
@@ -271,7 +271,7 @@ example_code_issue: |
     - id: AC2
       text: Tests pass for each operation
     - id: AC3
-      text: Errors match PRD error types
+      text: Errors match SRD error types
 
 sections:
   - tag: articles
@@ -291,7 +291,7 @@ sections:
     title: Documentation Issue Example
     content: |
       A worked example shows a properly structured documentation issue for
-      writing a PRD, including required reading, output path, format rule, and
+      writing a SRD, including required reading, output path, format rule, and
       acceptance criteria.
   - tag: example_code_issue
     title: Code Issue Example

--- a/docs/constitutions/semantic-model.yaml
+++ b/docs/constitutions/semantic-model.yaml
@@ -1,0 +1,237 @@
+# Semantic Model Constitution
+#
+# This constitution governs the authoring and validation of semantic models.
+# It is injected into the specification authoring phase so the Generator
+# (human or machine) knows how to produce well-formed, complete behavioral
+# specifications.
+#
+# A semantic model is the mutable behavioral layer of an agent specification.
+# It declares what the agent observes, how it reasons, and what it produces—
+# without prescribing code structure. The SRD defines architecture (stable).
+# The semantic model defines behavior (mutable). Constitutions and guidelines
+# constrain how behavior is implemented (prohibitive). The semantic model
+# declares what behavior IS (declarative).
+
+articles:
+  - id: SM1
+    title: Four mandatory sections
+    rule: |
+      Every semantic model must contain exactly four top-level sections:
+      data_sources, features, algorithm, and output_format. A semantic
+      model that omits any section is incomplete. A semantic model that
+      adds sections beyond these four is overspecified—move the extra
+      content to the SRD, architectural guidelines, or domain knowledge.
+
+      data_sources: what the agent observes (inputs)
+      features: how the agent interprets observations (derived signals)
+      algorithm: how the agent reasons (decision logic)
+      output_format: what the agent produces (outputs)
+
+  - id: SM2
+    title: Data sources are connectors, not implementations
+    rule: |
+      Each data source declares a connector type and a set of named
+      queries. The connector type names an interface or protocol—not a
+      library, endpoint URL, or implementation class. Queries declare
+      parameters and return types using domain types, not language-specific
+      types.
+
+      Good:
+        connector: INetworkState
+        queries:
+          - name: site_capacity
+            parameters: [site_id]
+            returns: {compute_available: float, memory_available: float}
+
+      Bad:
+        connector: "http://10.0.1.5:8080/api/v2"
+        queries:
+          - name: get_capacity
+            parameters: ["string siteId"]
+            returns: "json.RawMessage"
+
+      The semantic model specifies what data the agent needs, not where
+      or how it fetches it. Binding data sources to concrete endpoints
+      happens at deployment through configuration, not at specification
+      time through the semantic model.
+
+  - id: SM3
+    title: Features derive from data sources
+    rule: |
+      Every feature must reference at least one data source by id and
+      query name using dot notation (e.g., network_state.site_capacity).
+      Features that do not trace to a declared data source are untethered—
+      they claim to observe something the agent has no access to.
+
+      The extraction field describes the derivation in domain language,
+      not in code. It should be readable by a domain expert who does not
+      program. The Generator translates extraction descriptions into code;
+      the semantic model author describes the intent.
+
+      Features may reference other features to build derived signals.
+      Feature references must not form cycles. The dependency graph of
+      features must be a DAG.
+
+  - id: SM4
+    title: Algorithm declares logic, not code
+    rule: |
+      The algorithm section specifies the agent's reasoning as a named
+      type, a parameter set, and a logic block written in structured
+      pseudocode or domain language.
+
+      The type field names the reasoning pattern (e.g.,
+      threshold_with_trend, gap_ordered_task_generation,
+      ensemble_prediction). Types should be reusable across semantic
+      models—they name a family of algorithms, not a specific
+      implementation.
+
+      The parameters field declares the tunable knobs of the algorithm.
+      Parameters are the primary target of runtime configuration changes—
+      a threshold change should not require a specification delta if the
+      parameter is already declared.
+
+      The logic block is pseudocode, not executable code. It describes
+      the decision flow using feature names and domain concepts. The
+      Generator reads the logic block to understand the intended behavior
+      and produces the implementation. If the logic block is precise
+      enough to be executable, it is overspecified—it has become code
+      in disguise.
+
+  - id: SM5
+    title: Output format matches the functional interface
+    rule: |
+      The output_format section must align with the agent's IFunctional
+      interface as declared in the SRD. Every field in the output format
+      must correspond to a return type or response structure in the
+      functional interface.
+
+      If the semantic model produces outputs that IFunctional cannot
+      express, either the semantic model is wrong (specifying behavior
+      the architecture does not support) or the SRD needs a delta (the
+      architecture must grow to support the new behavior). This cross-
+      reference between semantic model and SRD is what makes specification
+      layers a graph, not a stack.
+
+  - id: SM6
+    title: One semantic model per behavior
+    rule: |
+      Each semantic model specifies one coherent behavior—one
+      observation-reasoning-output pipeline. An agent that performs
+      multiple behaviors (e.g., capacity prediction AND fault diagnosis)
+      has multiple semantic models, not one large one.
+
+      Semantic models are composed at the specification level. The
+      Specification Selector assembles the set of semantic models an
+      agent instance needs. The SRD defines the architectural slots
+      these models fill. Each slot corresponds to one behavioral
+      capability.
+
+      Splitting behaviors into separate semantic models enables
+      independent evolution. A new fault diagnosis algorithm does not
+      require re-specifying capacity prediction. The evolution pipeline
+      applies the delta to one semantic model without touching others.
+
+  - id: SM7
+    title: Naming and versioning
+    rule: |
+      Every semantic model has a name and a version.
+
+      The name follows the pattern: {domain}-{behavior}
+      Examples: edge-compute-capacity-predictor, transport-fault-diagnoser,
+      cobbler-measure, ran-latency-monitor.
+
+      The version follows semantic versioning (MAJOR.MINOR.PATCH):
+      - MAJOR: breaking changes to data sources or output format
+      - MINOR: new features or algorithm changes (backward compatible)
+      - PATCH: parameter tuning or extraction refinements
+
+      Version changes trigger different evolution responses. A PATCH
+      change may only require regenerating the algorithm implementation.
+      A MAJOR change may require regenerating data connectors, feature
+      extractors, and output formatters—touching multiple components.
+
+  - id: SM8
+    title: Semantic models are declarative, not prohibitive
+    rule: |
+      A semantic model declares what the agent DOES. It does not declare
+      what the agent must NOT do. Prohibitions belong in architectural
+      guidelines or constitutions.
+
+      Declarative (semantic model):
+        "Observe the specification tree, identify unimplemented use cases,
+        order by release priority, decompose into sized tasks."
+
+      Prohibitive (constitution/guideline):
+        "Do NOT propose tasks for implemented use cases."
+        "Do NOT exceed 350 lines per task."
+
+      If a statement in the semantic model begins with "do not," "never,"
+      "must not," or "avoid," it is a constraint and belongs in the
+      architectural guidelines layer. Move it there.
+
+      This separation matters because constraints are stable across
+      instances (every Analyst follows the same coding standards) while
+      behaviors are mutable per instance (each Analyst observes different
+      data and runs different algorithms).
+
+  - id: SM9
+    title: Testability
+    rule: |
+      Every semantic model must be testable through its output format.
+      Given known inputs to data_sources and known feature extractions,
+      the algorithm must produce deterministic or bounded outputs that
+      tests can verify.
+
+      When authoring a semantic model, ask: "Can I write a test that
+      provides mock data sources, runs the algorithm, and checks the
+      output?" If the answer is no, the semantic model is underspecified—
+      it does not declare enough about the algorithm's behavior for the
+      Generator to produce testable code.
+
+      The test suite layer of the agent specification contains tests
+      derived from the semantic model. Each feature should have at least
+      one test validating its extraction. The algorithm should have tests
+      for each branch of its logic. The output format should have tests
+      validating structure and value ranges.
+
+  - id: SM10
+    title: Domain knowledge references, not domain knowledge
+    rule: |
+      The semantic model may reference domain knowledge (ontologies,
+      protocol specs, vendor documentation) but must not embed it.
+      Data source connectors reference interface names defined in
+      domain knowledge. Feature extractions reference domain concepts
+      explained in domain knowledge. The semantic model says "use X";
+      domain knowledge defines what X is.
+
+      This separation keeps the semantic model portable. The same
+      capacity prediction semantic model can apply to different vendors
+      by swapping the domain knowledge binding—different equipment APIs,
+      same behavioral specification.
+
+sections:
+  - tag: articles
+    title: Core Principles
+    content: |
+      Ten principles govern semantic model authoring: four mandatory
+      sections (SM1), connector-based data sources (SM2), traceable
+      features (SM3), declarative algorithms (SM4), interface-aligned
+      outputs (SM5), one behavior per model (SM6), semantic versioning
+      (SM7), declarative not prohibitive (SM8), testability (SM9), and
+      referenced not embedded domain knowledge (SM10).
+  - tag: structure
+    title: Semantic Model Structure
+    content: |
+      A semantic model is a YAML document with four sections:
+      data_sources (inputs), features (derived signals), algorithm
+      (reasoning), and output_format (outputs). Each section has
+      specific structural requirements defined in the articles.
+  - tag: evolution
+    title: Semantic Model Evolution
+    content: |
+      The semantic model is the primary target for agent evolution.
+      Version changes signal the scope of regeneration needed. PATCH
+      changes tune parameters. MINOR changes add features or modify
+      algorithms. MAJOR changes alter inputs or outputs and may
+      require SRD changes. Each semantic model evolves independently
+      of others in the same agent.

--- a/docs/engineering/eng01-git-integration.yaml
+++ b/docs/engineering/eng01-git-integration.yaml
@@ -4,7 +4,7 @@ introduction: |
   This guideline describes how Crumbs integrates with git. The core rule is simple: JSONL
   files always live on main. Issue state is independent of code branches. Developers work
   on feature branches for code; the cupboard is always consulted from the data directory,
-  which is a fixed path resolved from configuration. See prd012-branch-independent-data
+  which is a fixed path resolved from configuration. See srd012-branch-independent-data
   for the requirements that govern this design.
 sections:
 - title: Data Directory in Git
@@ -68,8 +68,8 @@ sections:
     state. The data directory is a fixed path resolved from configuration; it is not scoped to
     a branch or worktree.
 references:
-- id: prd012-branch-independent-data
-  path: specs/product-requirements/prd012-branch-independent-data.yaml
+- id: srd012-branch-independent-data
+  path: specs/software-requirements/srd012-branch-independent-data.yaml
   note: requirements for branch-independent data persistence
 - id: ARCHITECTURE.yaml
   path: ARCHITECTURE.yaml

--- a/docs/engineering/eng02-beads-migration.md
+++ b/docs/engineering/eng02-beads-migration.md
@@ -36,5 +36,5 @@ Once scripts and the interactive workflow run on cupboard, we remove the bd depe
 ## References
 
 - eng01-git-integration (JSONL always on main, trails vs git branches)
-- prd012-branch-independent-data (requirements for branch-independent data persistence)
+- srd012-branch-independent-data (requirements for branch-independent data persistence)
 - docs/specs/use-cases/rel02.1-uc003-self-hosting.md (the use case this migration enables)

--- a/docs/engineering/eng03-cupboard-cli.yaml
+++ b/docs/engineering/eng03-cupboard-cli.yaml
@@ -3,7 +3,7 @@ title: Cupboard CLI Usage
 introduction: |
   This guideline describes how to install, configure, and use the cupboard command-line tool. We
   cover installation, initialization, configuration, and the full command set for managing crumbs
-  and issue tracking. For the formal specification, see prd009-cupboard-cli.yaml.
+  and issue tracking. For the formal specification, see srd009-cupboard-cli.yaml.
 sections:
 - title: Installation
   content: |
@@ -266,14 +266,14 @@ sections:
     Data migration involves moving from .beads/issues.jsonl to the cupboard data directory.
     Commit JSONL files from the data directory instead of .beads/ files.
 references:
-- id: prd009-cupboard-cli
-  path: specs/product-requirements/prd009-cupboard-cli.yaml
+- id: srd009-cupboard-cli
+  path: specs/software-requirements/srd009-cupboard-cli.yaml
   note: formal CLI specification
-- id: prd010-configuration-directories
-  path: specs/product-requirements/prd010-configuration-directories.yaml
+- id: srd010-configuration-directories
+  path: specs/software-requirements/srd010-configuration-directories.yaml
   note: directory structure and config loading
-- id: prd001-cupboard-core
-  path: specs/product-requirements/prd001-cupboard-core.yaml
+- id: srd001-cupboard-core
+  path: specs/software-requirements/srd001-cupboard-core.yaml
   note: Cupboard and Table interfaces
 - id: eng01-git-integration
   path: engineering/eng01-git-integration.yaml

--- a/docs/engineering/eng06-stitch-budget-validation.yaml
+++ b/docs/engineering/eng06-stitch-budget-validation.yaml
@@ -2,12 +2,12 @@ id: eng06-stitch-budget-validation
 title: Stitch Budget Validation
 introduction: |
   This guideline documents the stitch budget analysis for GH-15 (Recurring: Generate crumbs
-  code from specifications). Before running a full generation, we validate that every PRD
+  code from specifications). Before running a full generation, we validate that every SRD
   requirement group can be decomposed into tasks within stitch's sizing budget: 300-700 LOC
   of production code per task, at most 5 files per task, and at most one new subsystem
   boundary per task.
 
-  We analyzed all releases from rel01.0 through rel03.1, covering twelve PRDs. The analysis
+  We analyzed all releases from rel01.0 through rel03.1, covering twelve SRDs. The analysis
   produced per-release sizing tables with risk assessments for each proposed task. The overall
   conclusion is PROCEED WITH CAUTION: six releases are within budget, but four HIGH-risk tasks
   require pre-generation mitigations documented below.
@@ -23,12 +23,12 @@ introduction: |
   | Entity method requires Cupboard reference | — | MEDIUM |
 
   The analysis also identified a package naming discrepancy between eng05-testing-strategy
-  (which uses pkg/schema and internal/persistence) and the PRDs (which reference pkg/crumbs,
+  (which uses pkg/schema and internal/persistence) and the SRDs (which reference pkg/crumbs,
   pkg/properties, pkg/trails, etc.). This was resolved by GH-18 (corrected pkg/types references
-  in prd007 and prd008; expanded ARCHITECTURE.yaml project_structure with per-package PRD
+  in srd007 and srd008; expanded ARCHITECTURE.yaml project_structure with per-package SRD
   mappings). The four HIGH-risk task mitigations were applied via GH-19 (design decisions
-  R0.1, R0.2, R0.3 added to prd002; R0.1, R0.2 added to prd003;
-  R0.1 added to prd004; along with ordering requirements). GH-15 may proceed.
+  R0.1, R0.2, R0.3 added to srd002; R0.1, R0.2 added to srd003;
+  R0.1 added to srd004; along with ordering requirements). GH-15 may proceed.
 sections:
 - title: Totals by Release
   content: |
@@ -55,26 +55,26 @@ sections:
 
     Table 2 rel01.0 proposed tasks
 
-    | Task | PRDs covered | LOC prod | LOC test | Risk |
+    | Task | SRDs covered | LOC prod | LOC test | Risk |
     |------|-------------|----------|----------|------|
-    | Define Cupboard and Table interfaces | prd001 R1-R3, R7-R8 | 180 | — | LOW |
-    | Define SQLite schema and JSONL constants | prd002 R1-R3 | 260 | — | LOW |
-    | Attach, Detach, startup, shutdown sequence | prd002 R4, R6-R8, R11 | 420 | — | HIGH |
-    | Atomic JSONL write and sync strategy dispatch | prd002 R5.3-R5.4, R16, prd010 R6 | 310 | — | MEDIUM |
-    | GetTable routing and base table accessor | prd002 R12-R13 | 200 | — | LOW |
-    | Entity hydration and dehydration (ORM layer) | prd002 R14-R15 | 480 | — | HIGH |
-    | Built-in property seeding and graph audit | prd002 R9-R10 | 260 | — | LOW |
-    | Define Crumb struct, state values, creation defaults | prd003 R1-R3 | 190 | — | LOW |
-    | Crumb state transitions, property methods, and table accessor | prd003 R4-R11 | 360 | — | HIGH |
-    | Define Metadata struct and Schema struct | prd005 R1-R2, R10 | 140 | — | LOW |
-    | Metadata table accessor, built-in schemas, schema registration | prd005 R3-R9 | 300 | — | MEDIUM |
-    | Test: Cupboard lifecycle and JSONL roundtrip | prd001 R4-R6, prd002 R4, R6, R16 | — | 380 | LOW |
-    | Test: Crumb lifecycle and benchmarks | prd003 R1, R3-R5, R9-R10 | — | 450 | LOW |
-    | Test: Metadata interface and schema registration | prd005 R4, R6, R9 | — | 250 | LOW |
+    | Define Cupboard and Table interfaces | srd001 R1-R3, R7-R8 | 180 | — | LOW |
+    | Define SQLite schema and JSONL constants | srd002 R1-R3 | 260 | — | LOW |
+    | Attach, Detach, startup, shutdown sequence | srd002 R4, R6-R8, R11 | 420 | — | HIGH |
+    | Atomic JSONL write and sync strategy dispatch | srd002 R5.3-R5.4, R16, srd010 R6 | 310 | — | MEDIUM |
+    | GetTable routing and base table accessor | srd002 R12-R13 | 200 | — | LOW |
+    | Entity hydration and dehydration (ORM layer) | srd002 R14-R15 | 480 | — | HIGH |
+    | Built-in property seeding and graph audit | srd002 R9-R10 | 260 | — | LOW |
+    | Define Crumb struct, state values, creation defaults | srd003 R1-R3 | 190 | — | LOW |
+    | Crumb state transitions, property methods, and table accessor | srd003 R4-R11 | 360 | — | HIGH |
+    | Define Metadata struct and Schema struct | srd005 R1-R2, R10 | 140 | — | LOW |
+    | Metadata table accessor, built-in schemas, schema registration | srd005 R3-R9 | 300 | — | MEDIUM |
+    | Test: Cupboard lifecycle and JSONL roundtrip | srd001 R4-R6, srd002 R4, R6, R16 | — | 380 | LOW |
+    | Test: Crumb lifecycle and benchmarks | srd003 R1, R3-R5, R9-R10 | — | 450 | LOW |
+    | Test: Metadata interface and schema registration | srd005 R4, R6, R9 | — | 250 | LOW |
 
     The three HIGH-risk tasks:
 
-    Entity hydration and dehydration (prd002 R14-R15) covers seven entity types (Crumb,
+    Entity hydration and dehydration (srd002 R14-R15) covers seven entity types (Crumb,
     Trail, Property, Metadata, Link, Stash, StashHistory). Each type requires both hydration
     (SQL row to struct) and dehydration (struct to SQL params). Nullable pointer handling and
     UUID v7 generation add edge cases per type. At 480 LOC this task exceeds the 400-LOC
@@ -82,13 +82,13 @@ sections:
     Crumb, Trail, and Property (three core types, ~240 LOC); (b) hydration and dehydration
     for Metadata, Link, Stash, and StashHistory (four supporting types, ~240 LOC).
 
-    Attach, Detach, startup, and shutdown (prd002 R4, R6-R8, R11) at 420 LOC is borderline
+    Attach, Detach, startup, and shutdown (srd002 R4, R6-R8, R11) at 420 LOC is borderline
     HIGH. Startup (create dir, delete stale DB, load JSONL, validate FK) and shutdown (flush,
     close) are tightly coupled to the concurrency guard (RWMutex). Splitting is not recommended
     because a partial startup sequence is untestable independently. If actual LOC approaches
     600, extract the concurrency guard into a separate task first.
 
-    Crumb state transitions and table accessor (prd003 R4-R11) crosses two subsystems: entity
+    Crumb state transitions and table accessor (srd003 R4-R11) crosses two subsystems: entity
     methods live in pkg/schema (or equivalent), while the table accessor with filter logic lives
     in internal/persistence. We recommend splitting into: (a) entity methods only (SetState,
     Pebble, Dust, property methods, ~180 LOC, pkg/schema); (b) Crumbs table accessor with
@@ -101,16 +101,16 @@ sections:
 
     Table 3 rel01.1 proposed tasks
 
-    | Task | PRDs covered | LOC prod | LOC test | Risk |
+    | Task | SRDs covered | LOC prod | LOC test | Risk |
     |------|-------------|----------|----------|------|
-    | Config.yaml loading and directory resolution | prd010 R1-R3, R8-R9 | 210 | — | LOW |
-    | Cobra root command, init, and version | prd009 R1-R2, R6, R10 | 200 | — | LOW |
-    | Generic table commands (get, set, delete, list) | prd009 R3, R7-R9 | 340 | — | LOW |
-    | Crumb-specific commands (crumb add/get/list/delete) | prd009 R4 | 280 | — | LOW |
-    | Issue-tracking commands (ready, create, show, update, close, comments add) | prd009 R5 | 300 | — | LOW |
-    | Test: CLI configuration loading | prd010 R1-R2, R8 | — | 200 | LOW |
-    | Test: Generic table and crumb commands | prd009 R3-R4, R7-R8 | — | 420 | LOW |
-    | Test: Go install and self-hosting roundtrip | prd009 R2, prd010 R5 | — | 180 | LOW |
+    | Config.yaml loading and directory resolution | srd010 R1-R3, R8-R9 | 210 | — | LOW |
+    | Cobra root command, init, and version | srd009 R1-R2, R6, R10 | 200 | — | LOW |
+    | Generic table commands (get, set, delete, list) | srd009 R3, R7-R9 | 340 | — | LOW |
+    | Crumb-specific commands (crumb add/get/list/delete) | srd009 R4 | 280 | — | LOW |
+    | Issue-tracking commands (ready, create, show, update, close, comments add) | srd009 R5 | 300 | — | LOW |
+    | Test: CLI configuration loading | srd010 R1-R2, R8 | — | 200 | LOW |
+    | Test: Generic table and crumb commands | srd009 R3-R4, R7-R8 | — | 420 | LOW |
+    | Test: Go install and self-hosting roundtrip | srd009 R2, srd010 R5 | — | 180 | LOW |
 
     rel01.1 is the lowest-risk release. Stitch can generate it cleanly in a single cycle.
 
@@ -121,25 +121,25 @@ sections:
 
     Table 4 rel02.0 proposed tasks
 
-    | Task | PRDs covered | LOC prod | LOC test | Risk |
+    | Task | SRDs covered | LOC prod | LOC test | Risk |
     |------|-------------|----------|----------|------|
-    | Define Property and Category structs | prd004 R1-R3, R10 | 170 | — | LOW |
-    | Property table accessor with backfill enforcement | prd004 R4-R6 | 360 | — | HIGH |
-    | Category accessor and DefineCategory/GetCategories methods | prd004 R7-R9 | 270 | — | HIGH |
-    | Integrate property initialization into Crumb creation | prd003 R3.2, prd004 R4.2 | 120 | — | MEDIUM |
-    | Test: Property enforcement and backfill | prd004 R4, R7, R9, prd003 R3.2 | — | 320 | LOW |
+    | Define Property and Category structs | srd004 R1-R3, R10 | 170 | — | LOW |
+    | Property table accessor with backfill enforcement | srd004 R4-R6 | 360 | — | HIGH |
+    | Category accessor and DefineCategory/GetCategories methods | srd004 R7-R9 | 270 | — | HIGH |
+    | Integrate property initialization into Crumb creation | srd003 R3.2, srd004 R4.2 | 120 | — | MEDIUM |
+    | Test: Property enforcement and backfill | srd004 R4, R7, R9, srd003 R3.2 | — | 320 | LOW |
 
-    The backfill task (prd004 R4) is HIGH because property creation must atomically initialize
+    The backfill task (srd004 R4) is HIGH because property creation must atomically initialize
     default values on all existing crumbs. This is the only write operation in the system that
     scales with crumb count. At 360 LOC it is under the threshold, but the transactional
     complexity is elevated. We recommend that stitch generate this task with an explicit
     note to the agent: backfill must run inside a single SQLite transaction that can roll back
     if interrupted.
 
-    The Category task (prd004 R7-R9) is HIGH because DefineCategory and GetCategories are
-    entity methods on Property that require a Cupboard reference (prd004 R7.9, R8.6).
+    The Category task (srd004 R7-R9) is HIGH because DefineCategory and GetCategories are
+    entity methods on Property that require a Cupboard reference (srd004 R7.9, R8.6).
     This couples pkg/schema (entity layer) to the backend API at the entity method boundary.
-    The PRD allows implementations to expose a RegisterSchema method or a dedicated schemas
+    The SRD allows implementations to expose a RegisterSchema method or a dedicated schemas
     table; we recommend that stitch generate this as two separate tasks to isolate the
     coupling: (a) Category struct and DefineCategory/GetCategories signatures (pkg/schema);
     (b) Category table accessor and persistence (internal/persistence).
@@ -150,12 +150,12 @@ sections:
 
     Table 5 rel02.1 proposed tasks
 
-    | Task | PRDs covered | LOC prod | LOC test | Risk |
+    | Task | SRDs covered | LOC prod | LOC test | Risk |
     |------|-------------|----------|----------|------|
-    | Property-aware crumb commands (type, priority, labels, owner flags) | prd009 R4-R5 | 200 | — | LOW |
-    | Test: Issue-tracking CLI with properties | prd009 R4-R5, prd004 R9 | — | 310 | LOW |
-    | Test: Table benchmarks | prd003 R9-R10, prd004 R6 | — | 150 | LOW |
-    | Test: Metadata lifecycle operations | prd005 R6, R9 | — | 200 | LOW |
+    | Property-aware crumb commands (type, priority, labels, owner flags) | srd009 R4-R5 | 200 | — | LOW |
+    | Test: Issue-tracking CLI with properties | srd009 R4-R5, srd004 R9 | — | 310 | LOW |
+    | Test: Table benchmarks | srd003 R9-R10, srd004 R6 | — | 150 | LOW |
+    | Test: Metadata lifecycle operations | srd005 R6, R9 | — | 200 | LOW |
 
     rel02.1 can run after rel02.0 is complete and all property integration tests pass.
 
@@ -167,17 +167,17 @@ sections:
 
     Table 6 rel03.0 proposed tasks
 
-    | Task | PRDs covered | LOC prod | LOC test | Risk |
+    | Task | SRDs covered | LOC prod | LOC test | Risk |
     |------|-------------|----------|----------|------|
-    | Define Trail struct and lifecycle entity methods | prd006 R1-R6, R8 | 165 | — | LOW |
-    | Trail table accessor with Complete and Abandon cascade | prd006 R5.6-R5.7, R6.6-R8, R9, prd002 R5.6-R5.7 | 430 | — | HIGH |
-    | Define shared type constants (LinkType, StashType, operation codes) | prd007 R2.2, prd008 R2, R7.3 | 80 | — | LOW |
-    | Link table accessor with cardinality and DAG validation | prd007 R1, R3-R8 | 310 | — | MEDIUM |
-    | Define Stash struct and value/counter/lock entity methods | prd008 R1-R2, R4-R7, R12-R13 | 260 | — | LOW |
-    | Stash table accessor with history tracking | prd008 R3, R8-R11 | 340 | — | MEDIUM |
-    | Test: Trail lifecycle and cascade (uc001, uc004) | prd006 R5-R7, R9 | — | 420 | LOW |
-    | Test: Link management and cardinality (uc002) | prd007 R5-R6, R8 | — | 260 | LOW |
-    | Test: Stash operations and history tracking (uc003) | prd008 R3, R5-R7, R13 | — | 310 | LOW |
+    | Define Trail struct and lifecycle entity methods | srd006 R1-R6, R8 | 165 | — | LOW |
+    | Trail table accessor with Complete and Abandon cascade | srd006 R5.6-R5.7, R6.6-R8, R9, srd002 R5.6-R5.7 | 430 | — | HIGH |
+    | Define shared type constants (LinkType, StashType, operation codes) | srd007 R2.2, srd008 R2, R7.3 | 80 | — | LOW |
+    | Link table accessor with cardinality and DAG validation | srd007 R1, R3-R8 | 310 | — | MEDIUM |
+    | Define Stash struct and value/counter/lock entity methods | srd008 R1-R2, R4-R7, R12-R13 | 260 | — | LOW |
+    | Stash table accessor with history tracking | srd008 R3, R8-R11 | 340 | — | MEDIUM |
+    | Test: Trail lifecycle and cascade (uc001, uc004) | srd006 R5-R7, R9 | — | 420 | LOW |
+    | Test: Link management and cardinality (uc002) | srd007 R5-R6, R8 | — | 260 | LOW |
+    | Test: Stash operations and history tracking (uc003) | srd008 R3, R5-R7, R13 | — | 310 | LOW |
 
     The Trail cascade task is the most complex in the project. The Abandon path deletes
     crumbs, crumb_properties, metadata, child_of links, and belongs_to links — all atomically
@@ -197,10 +197,10 @@ sections:
 
     Table 7 rel03.1 proposed tasks
 
-    | Task | PRDs covered | LOC prod | LOC test | Risk |
+    | Task | SRDs covered | LOC prod | LOC test | Risk |
     |------|-------------|----------|----------|------|
-    | Trail CLI commands (trail create, add-crumb, complete, abandon, list) | prd009 R1, prd006 R3, R5-R6 | 260 | — | LOW |
-    | Test: Self-hosting with epics via trails (uc001) | prd006 R5-R7, prd007 R6, prd009 R4 | — | 370 | LOW |
+    | Trail CLI commands (trail create, add-crumb, complete, abandon, list) | srd009 R1, srd006 R3, R5-R6 | 260 | — | LOW |
+    | Test: Self-hosting with epics via trails (uc001) | srd006 R5-R7, srd007 R6, srd009 R4 | — | 370 | LOW |
 
     rel03.1 is well within budget and requires no pre-generation mitigation.
 
@@ -212,33 +212,33 @@ sections:
 
     | Priority | Action | Blocking? | Owner |
     |----------|--------|-----------|-------|
-    | 1 | Resolve package naming discrepancy between eng05 and PRDs | RESOLVED (GH-18) | Architecture |
-    | 2 | Split entity hydration task (prd002 R14-R15) into two tasks | RESOLVED (GH-19) | Architecture |
-    | 3 | Split Crumb state+property task (prd003 R4-R11) into two tasks | RESOLVED (GH-19) | Architecture |
-    | 4 | Add transaction requirement to Property backfill task (prd004 R4) | RESOLVED (GH-19) | Architecture |
+    | 1 | Resolve package naming discrepancy between eng05 and SRDs | RESOLVED (GH-18) | Architecture |
+    | 2 | Split entity hydration task (srd002 R14-R15) into two tasks | RESOLVED (GH-19) | Architecture |
+    | 3 | Split Crumb state+property task (srd003 R4-R11) into two tasks | RESOLVED (GH-19) | Architecture |
+    | 4 | Add transaction requirement to Property backfill task (srd004 R4) | RESOLVED (GH-19) | Architecture |
 
     Resolve package naming (resolved by GH-18). ARCHITECTURE.yaml now defines an expanded
-    project_structure with per-package prds and role_detail fields. The canonical packages are
+    project_structure with per-package srds and role_detail fields. The canonical packages are
     pkg/api (interfaces), pkg/schema (all entity structs and methods), pkg/constants (all domain
     strings), internal/persistence/engine (SQLite lifecycle), internal/persistence/mapping
     (hydration/dehydration), internal/persistence/ (Table implementations), and cmd/cupboard
-    (CLI). The explicit pkg/types references in prd007 R2.2 and prd008 R7.3, R7.5, R12.1 have
+    (CLI). The explicit pkg/types references in srd007 R2.2 and srd008 R7.3, R7.5, R12.1 have
     been corrected to pkg/constants, pkg/schema, and pkg/api respectively. No package name
-    ambiguity remains across PRDs, eng05, and ARCHITECTURE.yaml.
+    ambiguity remains across SRDs, eng05, and ARCHITECTURE.yaml.
 
-    Split hydration task (prd002 R14-R15) — resolved by GH-19. Design decision R0.1 and
-    ordering requirement R14.0 added to prd002. R14 is split into R14.1 (Crumb, Trail, Property)
+    Split hydration task (srd002 R14-R15) — resolved by GH-19. Design decision R0.1 and
+    ordering requirement R14.0 added to srd002. R14 is split into R14.1 (Crumb, Trail, Property)
     and R14.2 (Metadata, Link, Stash, StashHistory). R15 is split into R15.9 and R15.10. Stitch
     will read these group labels and generate two tasks at ~240 LOC each without agent inference.
 
-    Split Crumb state+property task (prd003 R4-R11) — resolved by GH-19. Design decisions
+    Split Crumb state+property task (srd003 R4-R11) — resolved by GH-19. Design decisions
     R0.1 (entity methods in pkg/schema/crumb.go) and R0.2 (table accessor in
-    internal/persistence/crumbs_table.go) added to prd003. R4.0 ordering requirement and R6.0
+    internal/persistence/crumbs_table.go) added to srd003. R4.0 ordering requirement and R6.0
     group marker added. Stitch will generate two tasks: (a) entity methods (~180 LOC); (b)
     Crumbs table accessor (~200 LOC).
 
-    Add transaction note to Property backfill (prd004 R4) — resolved by GH-19. Design decision
-    R0.1 added to prd004. R4.3 and R4.4 specify the exact 5-step transaction algorithm
+    Add transaction note to Property backfill (srd004 R4) — resolved by GH-19. Design decision
+    R0.1 added to srd004. R4.3 and R4.4 specify the exact 5-step transaction algorithm
     and the same-transaction SELECT constraint. Stitch agents have unambiguous instructions;
     no inference required. Non-goal added to scope out incremental backfill.
 
@@ -264,9 +264,9 @@ sections:
     LOC production is comfortably below the 400-LOC HIGH threshold.
 
     Four HIGH-risk tasks existed across rel01.0, rel02.0, and rel03.0. All four have been
-    mitigated at the specification level via GH-19. Design decisions (prd002 R0.1-R0.3,
-    prd003 R0.1-R0.2, prd004 R0.1) and ordering requirements (R14.0, R4.0) are now
-    embedded in prd002, prd003, and prd004. Stitch agents read these directly; no inference
+    mitigated at the specification level via GH-19. Design decisions (srd002 R0.1-R0.3,
+    srd003 R0.1-R0.2, srd004 R0.1) and ordering requirements (R14.0, R4.0) are now
+    embedded in srd002, srd003, and srd004. Stitch agents read these directly; no inference
     about task boundaries is required.
 
     The package naming blocking action is resolved by GH-18. All four HIGH-risk mitigations

--- a/docs/engineering/eng07-srd-release-scoping.yaml
+++ b/docs/engineering/eng07-srd-release-scoping.yaml
@@ -1,22 +1,22 @@
-id: eng07-prd-release-scoping
-title: PRD-to-Release Scoping
+id: eng07-srd-release-scoping
+title: SRD-to-Release Scoping
 introduction: |
-  Crumbs PRDs span multiple releases because the architecture is layered: the same
+  Crumbs SRDs span multiple releases because the architecture is layered: the same
   interfaces (Cupboard, Table, entity structs) grow incrementally across releases. This
-  differs from projects like go-unix-utils where each PRD maps to exactly one utility and
+  differs from projects like go-unix-utils where each SRD maps to exactly one utility and
   one release. This guideline documents why the layered pattern exists, its impact on AI
   agent effectiveness, and conventions for managing it.
 sections:
-- title: Structural Difference from Per-Release PRDs
+- title: Structural Difference from Per-Release SRDs
   content: |
-    In go-unix-utils, each PRD describes one Unix utility. A utility is self-contained:
-    its requirements, tests, and implementation belong to a single release. The PRD-to-release
+    In go-unix-utils, each SRD describes one Unix utility. A utility is self-contained:
+    its requirements, tests, and implementation belong to a single release. The SRD-to-release
     mapping is 1:1.
 
     Crumbs has a layered architecture where a small number of interfaces serve all releases.
-    prd001-cupboard-core defines Attach, GetTable, and Detach -- used by every release from
-    rel01.0 onward. prd002-sqlite-backend defines schema creation, JSONL sync, and hydration
-    -- consumed by every use case that touches persistence. A single PRD like prd002 contains
+    srd001-cupboard-core defines Attach, GetTable, and Detach -- used by every release from
+    rel01.0 onward. srd002-sqlite-backend defines schema creation, JSONL sync, and hydration
+    -- consumed by every use case that touches persistence. A single SRD like srd002 contains
     requirements exercised by rel01.0 (basic schema), rel02.0 (property tables), rel03.0
     (trail and link tables), and rel04.0 (branch-independent JSONL).
 
@@ -25,36 +25,36 @@ sections:
 
 - title: Impact on AI Agent Effectiveness
   content: |
-    The multi-release PRD pattern affects the measure agent in two ways.
+    The multi-release SRD pattern affects the measure agent in two ways.
 
-    First, when measure reads a PRD to propose tasks for a release, it sees requirements
+    First, when measure reads a SRD to propose tasks for a release, it sees requirements
     from all releases. Without guidance, it may propose tasks for requirements that belong
     to a later release. The mitigation is touchpoint specificity: each use case cites the
-    exact PRD requirement IDs it exercises. The measure agent should scope work to the
-    requirements cited by the current release's use cases, not the full PRD.
+    exact SRD requirement IDs it exercises. The measure agent should scope work to the
+    requirements cited by the current release's use cases, not the full SRD.
 
-    Second, the analyze warning "PRDs spanning multiple releases" creates noise. Every run
-    reports 9 PRDs spanning releases. This is expected and should not trigger corrective
+    Second, the analyze warning "SRDs spanning multiple releases" creates noise. Every run
+    reports 9 SRDs spanning releases. This is expected and should not trigger corrective
     action. The warning exists to catch accidental cross-release coupling in projects with
-    per-release PRDs; in crumbs, it is informational.
+    per-release SRDs; in crumbs, it is informational.
 
-- title: Convention for Future PRDs
+- title: Convention for Future SRDs
   content: |
-    The layered pattern is accepted for crumbs. New PRDs should follow these conventions:
+    The layered pattern is accepted for crumbs. New SRDs should follow these conventions:
 
-    1. A PRD may span releases when it describes a shared interface or backend that grows
+    1. A SRD may span releases when it describes a shared interface or backend that grows
        incrementally. Examples: Cupboard interface, SQLite backend, Table interface.
 
-    2. A PRD should be scoped to one release when it describes a self-contained feature
-       with no cross-release growth. Example: prd012-branch-independent-data is only
+    2. A SRD should be scoped to one release when it describes a self-contained feature
+       with no cross-release growth. Example: srd012-branch-independent-data is only
        referenced by rel04.0.
 
-    3. Requirements within a multi-release PRD must use the R-number format (R1.1, R14.2)
+    3. Requirements within a multi-release SRD must use the R-number format (R1.1, R14.2)
        so that use case touchpoints can cite specific requirements per release.
 
     4. Use case touchpoints are the primary scoping mechanism. Each touchpoint must cite
-       both the PRD ID and the specific requirement numbers. Vague references like
-       "(prd002-sqlite-backend)" without requirement numbers are not acceptable.
+       both the SRD ID and the specific requirement numbers. Vague references like
+       "(srd002-sqlite-backend)" without requirement numbers are not acceptable.
 
 - title: Mitigation for Requirement Ownership
   content: |
@@ -63,7 +63,7 @@ sections:
     by tracing use case touchpoints:
 
     1. For each release, collect all touchpoints from its use cases.
-    2. The union of cited PRD requirement IDs defines the requirements owned by that release.
+    2. The union of cited SRD requirement IDs defines the requirements owned by that release.
     3. Requirements not cited by any use case touchpoint are unowned and should be reviewed
        for relevance.
 

--- a/docs/prompts/measure.yaml
+++ b/docs/prompts/measure.yaml
@@ -4,7 +4,7 @@ role: |
 task: |
   Follow these steps in order. Complete each step before moving to the next. Do NOT explore the filesystem, read files, or run commands unless a step explicitly asks you to. All project information is already provided in the project_context field above.
 
-  1. **Analyze project context** — Review the project_context field above. It contains ALL project documentation: vision, architecture, specifications, roadmap, PRDs, use cases, test suites, engineering guidelines, constitutions, and existing issues. Do NOT read any files — everything you need is inline.
+  1. **Analyze project context** — Review the project_context field above. It contains ALL project documentation: vision, architecture, specifications, roadmap, SRDs, use cases, test suites, engineering guidelines, constitutions, and existing issues. Do NOT read any files — everything you need is inline.
 
   2. **Summarize project state** — Write a brief summary of:
      - What problem this project solves
@@ -20,36 +20,25 @@ task: |
 
   4. **Propose tasks** — For each task, write a description that follows the crumb-format YAML schema (see planning_constitution above and output_format below). Remember: the stitch agent sees ONLY the task description and the execution constitution. It does not see your analysis, the existing issues, or this conversation. The description must be self-contained.
 
-  5. **Return output** — Return the proposed tasks as a YAML list in your text output, inside a fenced code block marked ```yaml. Do NOT use any tools. Your entire response is text only.
+  5. **Write output** — Append the proposed tasks as a YAML list to `{output_path}` using the Write tool.
 
 constraints: |
-  - Do NOT use any tools. Do NOT explore the filesystem, read files, or run commands. All project information is in the project_context above. Your response must be text only with zero tool calls.
-  - Do NOT interact with the issue tracker directly.
+  - Do NOT explore the filesystem. Do NOT run ls, find, tree, or similar commands. Do NOT read files. All project information is in the project_context above.
+  - Do NOT interact with the issue tracker directly. Write the tasks to `{output_path}` using the Write tool.
+  - Do NOT read docs/ files with tools. All documentation is provided in the project_context above.
   - Do NOT duplicate existing issues. Review the issues in the project_context above before proposing.
-  - Issues with status "closed" represent COMPLETED work. Do not re-propose work that a closed issue already covers, even under a different title or framing. The completed_work field in project_context lists all finished tasks — treat every entry as work that must not be repeated.
-  - When source_code contains .go files for a package, that package already exists. Do not propose creating or reimplementing it. Trust the source code over prose descriptions in documentation (e.g., implementation_status sections in ARCHITECTURE.yaml may be stale).
-  - If the source code already fully implements all requirements for the current release and no meaningful implementation work remains, return an empty YAML list: ```yaml\n[]\n```. An empty list is the correct and expected output when the spec is complete. Do NOT propose verification tasks, clean-up tasks, or minor follow-ups just to produce output — return `[]` instead.
-  - Components with a provided_by field in ARCHITECTURE.yaml are external infrastructure. Do NOT propose tasks that create or modify files in those components.
   - Do NOT exceed {limit} tasks. If more work is needed, create additional tasks in a future session.
   - Do NOT create tasks larger than {lines_max} lines of production code. Target {lines_min}-{lines_max} lines per task, touching 5-7 files. Split aggressively: a task that creates a struct and implements its methods is two tasks.
-  - Each task must contain at most {max_requirements} PRD sub-requirements (e.g., R1.1, R2.3), not requirement groups. Split any task that would exceed this limit.
+  - SRD requirements use a two-level structure: R-groups (R1, R2, R3) contain sub-requirements (R1.1, R1.2, R2.1). When referencing requirements, always use sub-requirement IDs (e.g., "srd003 R2.1, R2.2, R2.3"), not group IDs. A reference to "srd003 R2" means ALL sub-requirements under R2, which may be 10+ items. Each task must contain at most {max_requirements} SRD sub-requirements total. Count every sub-requirement individually: "srd003 R2.1, R2.2, R2.3" is 3 sub-requirements, while "srd003 R2" expands to however many items R2 contains. Split tasks that would exceed the limit.
   - Each task MUST be independently executable by an agent that has no context beyond the task description and the execution constitution.
   - Do NOT assume the stitch agent has access to your analysis, the existing issues list, or any context from this conversation.
   - Do NOT propose tasks that require human judgment or manual testing. Each task must have checkable acceptance criteria.
-  - Anchor every task to specific PRD requirement IDs (e.g., prd001 R1.1). Include the requirement ID in the task title. Given the same PRD and release, the same tasks should be proposed regardless of how many times this prompt is run.
-  - When requirement_states is present in project_context, only propose tasks for R-items with status "ready". R-items with status "complete", "complete_with_failures", or "skip" must not be re-proposed. If all R-items for the current release are complete or skipped, return an empty list.
-  - Before proposing implementation tasks for a new package, propose a contract task that defines all exported types, interfaces, and function signatures as Go stubs. Title it with the suffix "(contract)" and set its dependency to -1. Implementation tasks for that package must list the contract file in required_reading and depend on the contract task. Do not propose implementation tasks for a package that has no contract task unless the package already exists in source_code.
-  - Order tasks canonically: documentation before code, contracts before implementations, types before consumers, implementation before tests. Break ties by primary file path alphabetically.
-  - Derive file names from PRD/architecture names, not invented names. If the architecture calls a component "crumb", the file is crumb.go.
-  - Do NOT invent design decisions not derived from the PRD or architecture. Derive struct shapes, timeout strategies, file names, and naming conventions from the PRD rather than making arbitrary choices. If the PRD does not specify a detail, omit it from design decisions rather than inventing one.
-  - When a PRD specifies a concrete design choice (e.g., "use a FileExpectation struct", "the main file is difftest.go", "timeout is configurable via context"), copy that choice verbatim into the task's design_decisions. Do not rephrase, generalize, or substitute alternatives. The PRD is the single source of truth for implementation details.
-  - Do NOT vary requirement count between equivalent runs. Each PRD requirement maps to one task requirement. Given the same input, produce the same requirement set. If two runs of this prompt against the same project state would produce different requirements, the decomposition is under-constrained -- tighten it.
-  - Do NOT make any tool calls. Return the YAML list directly in your text output.
+  - The ONLY tool call you should make is the Write tool to save the output YAML file.
 
 output_format: |
-  Return a YAML list of crumb objects inside a fenced code block (```yaml). Each crumb has a sequential `index` (starting at 0) and a `dependency` field. Set `dependency` to the index of the crumb that must be completed first, or `-1` if there are no dependencies.
+  Write a YAML list of crumb objects to `{output_path}`. Each crumb has a sequential `index` (starting at 0) and a `dependency` field. Set `dependency` to the index of the crumb that must be completed first, or `-1` if there are no dependencies.
 
-  The `description` field must be a valid YAML document conforming to the issue_format_constitution injected above. Write it as a YAML literal block scalar. Use ASCII dashes, not Unicode em dashes. Requirements, design decisions, and acceptance criteria are all mappings with `id:` and `text:` fields (R1/R2/..., D1/D2/..., AC1/AC2/...).
+  The `description` field must follow the crumb-format YAML schema from the planning_constitution. Write it as a YAML literal block scalar.
 
   Example:
     - index: 0
@@ -60,7 +49,7 @@ output_format: |
 
         required_reading:
           - path/to/file.go (reason this file must be read)
-          - docs/specs/product-requirements/prd001-feature.yaml
+          - docs/specs/software-requirements/srd001-feature.yaml
 
         files:
           - path: pkg/types/example.go
@@ -71,22 +60,17 @@ output_format: |
             note: ExampleType implementation
 
         requirements:
-          - id: R1
-            text: Implement ExampleType per prd001-feature R2
-          - id: R2
-            text: Add Get and Set operations
+          - "R1: Implement ExampleType struct per srd001-feature R2.1, R2.2"
+          - "R2: Add Get operation per srd001-feature R2.3"
+          - "R3: Add Set operation per srd001-feature R2.4"
 
         design_decisions:
-          - id: D1
-            text: Use table accessor pattern from prd001-cupboard-core
-          - id: D2
-            text: "Keep implementation in internal/, not pkg/"
+          - Use table accessor pattern from srd001-cupboard-core
+          - "Keep implementation in internal/, not pkg/"
 
         acceptance_criteria:
-          - id: AC1
-            text: All operations implemented and tested
-          - id: AC2
-            text: Tests pass for each operation
+          - All operations implemented and tested
+          - Tests pass for each operation
 
     - index: 1
       title: Task that depends on task 0
@@ -103,15 +87,11 @@ output_format: |
             note: integration tests
 
         requirements:
-          - id: R1
-            text: Test all ExampleType operations end to end
+          - "R1: Test all ExampleType operations end to end"
 
         acceptance_criteria:
-          - id: AC1
-            text: All tests pass
+          - All tests pass
 
-  The description must be self-contained. All five fields (deliverable_type, required_reading, files, requirements, acceptance_criteria) are required. Each requirement, design_decision, and acceptance_criteria entry is a mapping with `id` and `text` fields. Add design_decisions when the stitch agent must follow specific patterns or architecture constraints.
+  The description must be self-contained. All five fields (deliverable_type, required_reading, files, requirements, acceptance_criteria) are required. Add design_decisions when the stitch agent must follow specific patterns or architecture constraints.
 
-  When a golden_example field is present in this prompt, it is the authoritative reference for style, granularity, and naming conventions. Match its requirement count range, acceptance criteria density, design decision style, and file naming pattern. Deviate from the golden example only when the PRD explicitly requires a different structure.
-
-  The orchestrator will parse the YAML from your text output and import the tasks into the issue tracker.
+  The tasks will be automatically imported into the issue tracker.

--- a/docs/prompts/stitch.yaml
+++ b/docs/prompts/stitch.yaml
@@ -4,7 +4,7 @@ role: |
 task: |
   Follow these steps in order. Complete each step before moving to the next.
 
-  1. **Review provided context** — The project_context section above already contains all project documentation, PRDs, source code, shared_protocols, and package_contracts inline in this prompt. Review Required Reading files by scrolling up to find them in project_context — do NOT call the Read, Glob, or Grep tools for any file already present above. The only files you may read with tools are files NOT in project_context (e.g. files you are about to create or modify).
+  1. **Review provided context** — The project_context above contains all project documentation and source code. Review the files listed in Required Reading by finding them in the project_context. Only use tools to read files that are NOT already provided above.
 
   2. **Plan approach** — Before writing code, determine:
      - What exists already (interfaces, types, patterns in the source code above)
@@ -16,16 +16,10 @@ task: |
   4. **Verify** — Check every item in Acceptance Criteria. Run tests if the criteria require it. Do not skip any criterion.
 
 constraints: |
-  - Do NOT read any file in the repository to infer style, patterns, or conventions. All style guidance is provided in go_style_constitution above. All source patterns are provided in project_context above. If a file you need is absent from project_context, write it from scratch following go_style_constitution — do not read the filesystem to fill the gap.
-  - Do NOT use Read, Glob, or Grep tools on files already in project_context. PRDs, source code, ARCHITECTURE, VISION, shared_protocols, package_contracts — all are inline above. Reading them again wastes a turn and adds no information. Only use Read for files not present in project_context.
+  - Do NOT read files already provided in project_context. They are already inline above.
   - Do NOT explore the filesystem. Do NOT run ls, find, tree, or similar commands.
   - Do NOT modify files outside the Files to Create/Modify list unless a requirement explicitly demands it.
   - Do NOT use bd or cupboard commands. Task tracking is handled externally.
-  - Do NOT invent interfaces, types, or patterns not described in the source code, Required Reading, or PRDs.
+  - Do NOT invent interfaces, types, or patterns not described in the source code, Required Reading, or SRDs.
   - Do NOT add features, refactoring, or improvements beyond what the requirements specify.
   - Do NOT run any git commands. No git add, git commit, git init, git status, rm .git, or any other git operation. Git is managed externally by the orchestrator. Just write code and verify it compiles and passes tests.
-  - When building cmd/ binaries to verify compilation, use `go build -o bin/<name> ./cmd/<name>/` so outputs land in bin/ (which is git-ignored) rather than in the working directory.
-  - When a build or lint step fails, read ALL error and warning messages before making any changes. Fix every reported issue in a single edit pass, then run the build once to verify. Do not fix one issue, rebuild, fix the next — batch all fixes into one round.
-  - When modifying more than 3 locations in the same file, prefer the Write tool (full file replacement) over multiple Edit calls. Each Edit changes the file, invalidating old_string matches for subsequent Edits. Write avoids this by producing the complete file in one call.
-  - The test suite is the acceptance gate. Do not manually run binaries to compare output against reference implementations. Run `go test` and fix any failures. Manual comparison is only warranted when a test fails and the expected behavior is ambiguous.
-  - Complete all code changes before running `go build` or `go test`. Do not compile incrementally after each small edit. Mentally verify imports, types, and function signatures, then build once.

--- a/docs/specs/software-requirements/srd001-cupboard-core.yaml
+++ b/docs/specs/software-requirements/srd001-cupboard-core.yaml
@@ -1,9 +1,9 @@
-id: "prd001-cupboard-core"
+id: "srd001-cupboard-core"
 title: Cupboard Core Interface
 problem: |
   Applications using Crumbs need a consistent way to initialize storage, access data tables, and manage the cupboard lifecycle. Without a well-defined core interface, each application must handle backend initialization differently, leading to duplicated setup code and inconsistent error handling. We need a single entry point that accepts configuration, provides uniform table access, and cleanly releases resources when done.
 
-  This PRD defines the cupboard lifecycle interface: configuration, table access, and shutdown. It establishes the contract that all backends must implement.
+  This SRD defines the cupboard lifecycle interface: configuration, table access, and shutdown. It establishes the contract that all backends must implement.
 goals:
 - G1: "Define a Config struct that selects backends and provides backend-specific parameters"
 - G2: Define the Cupboard interface with uniform table access via GetTable
@@ -74,9 +74,9 @@ requirements:
           \ Callers use type assertions to access entity-specific fields"
         weight: 5
     - R3.7:
-        text: "Entity structs are defined in their respective interface PRDs (Crumb in prd003-crumbs-interface, Trail in prd006-trails-interface,\
-          \ Property in prd004-properties-interface, Metadata in prd005-metadata-interface, Link in prd002-sqlite-backend,\
-          \ Stash in prd008-stash-interface)"
+        text: "Entity structs are defined in their respective interface SRDs (Crumb in srd003-crumbs-interface, Trail in srd006-trails-interface,\
+          \ Property in srd004-properties-interface, Metadata in srd005-metadata-interface, Link in srd002-sqlite-backend,\
+          \ Stash in srd008-stash-interface)"
         weight: 1
   R4:
     title: Attach
@@ -165,12 +165,12 @@ package_contract:
   import_constraints:
   - "pkg/api must not import pkg/schema, internal/, or cmd/"
 non_goals:
-- "This PRD does not define entity-specific schemas or operations. Entity types are defined in their respective interface\
-  \ PRDs (prd003-crumbs-interface, prd006-trails-interface, etc.)."
-- "This PRD does not define backend-specific behavior. Backends may add optional methods beyond the interface."
-- This PRD does not define HTTP/RPC wrappers around the Cupboard interface. Applications define their own APIs.
-- This PRD does not define connection pooling or retry policies. Backends may implement these internally.
-- "This PRD does not define specialized query operations beyond Fetch. Entity-specific PRDs may specify additional query requirements\
+- "This SRD does not define entity-specific schemas or operations. Entity types are defined in their respective interface\
+  \ SRDs (srd003-crumbs-interface, srd006-trails-interface, etc.)."
+- "This SRD does not define backend-specific behavior. Backends may add optional methods beyond the interface."
+- This SRD does not define HTTP/RPC wrappers around the Cupboard interface. Applications define their own APIs.
+- This SRD does not define connection pooling or retry policies. Backends may implement these internally.
+- "This SRD does not define specialized query operations beyond Fetch. Entity-specific SRDs may specify additional query requirements\
   \ that backends implement via filter conventions."
 acceptance_criteria:
 - id: AC1

--- a/docs/specs/software-requirements/srd002-sqlite-backend.yaml
+++ b/docs/specs/software-requirements/srd002-sqlite-backend.yaml
@@ -1,11 +1,11 @@
-id: "prd002-sqlite-backend"
+id: "srd002-sqlite-backend"
 title: SQLite Backend
 problem: |
-  The SQLite backend needs a detailed specification for how JSONL files and SQLite interact. prd001-cupboard-core establishes that JSONL is the source of truth and SQLite serves as a query engine, but it does not specify the JSONL file format, SQLite schema, sync lifecycle, or error handling. Without this detail, implementation will make ad-hoc decisions that may not align with project goals.
+  The SQLite backend needs a detailed specification for how JSONL files and SQLite interact. srd001-cupboard-core establishes that JSONL is the source of truth and SQLite serves as a query engine, but it does not specify the JSONL file format, SQLite schema, sync lifecycle, or error handling. Without this detail, implementation will make ad-hoc decisions that may not align with project goals.
 
-  The backend must also implement the uniform Table interface defined in prd001-cupboard-core. Applications access data through `cupboard.GetTable("crumbs").Get(id)`, not through entity-specific methods. The backend must hydrate table rows into entity objects and persist entity objects back to rows. This ORM-style pattern keeps the interface consistent while allowing each entity type to have its own struct.
+  The backend must also implement the uniform Table interface defined in srd001-cupboard-core. Applications access data through `cupboard.GetTable("crumbs").Get(id)`, not through entity-specific methods. The backend must hydrate table rows into entity objects and persist entity objects back to rows. This ORM-style pattern keeps the interface consistent while allowing each entity type to have its own struct.
 
-  This PRD specifies the SQLite backend internals: JSONL file layout, SQLite schema, startup loading, write persistence, shutdown flushing, error recovery, concurrency model, and the ORM layer that maps between Table operations and entity types.
+  This SRD specifies the SQLite backend internals: JSONL file layout, SQLite schema, startup loading, write persistence, shutdown flushing, error recovery, concurrency model, and the ORM layer that maps between Table operations and entity types.
 
   We store data as a directed acyclic graph (DAG). Crumbs and trails are nodes; relationships are edges stored in link tables. This separates how we store data from how we access it, enabling efficient queries for both.
 
@@ -261,7 +261,7 @@ requirements:
     title: Cupboard Interface Implementation
     items:
     - R11.1:
-        text: "The SQLite backend implements the Cupboard interface defined in prd001-cupboard-core"
+        text: "The SQLite backend implements the Cupboard interface defined in srd001-cupboard-core"
         weight: 1
     - R11.3:
         text: Attach must store the Config and mark the cupboard as attached. Subsequent Attach calls return ErrAlreadyAttached
@@ -433,9 +433,9 @@ package_contract:
   - "internal/persistence/engine must not import pkg/schema (entity-agnostic)"
   - internal/persistence/mapping must not import internal/persistence/engine
 non_goals:
-- "This PRD does not define the Cupboard interface operations. Those are in prd001-cupboard-core and the interface PRDs"
-- "This PRD does not define cross-process locking. Single-process access is assumed"
-- This PRD does not define backup or migration utilities
+- "This SRD does not define the Cupboard interface operations. Those are in srd001-cupboard-core and the interface SRDs"
+- "This SRD does not define cross-process locking. Single-process access is assumed"
+- This SRD does not define backup or migration utilities
 acceptance_criteria:
 - id: AC1
   criterion: Directory layout specified with DataDir structure and file creation behavior

--- a/docs/specs/software-requirements/srd003-crumbs-interface.yaml
+++ b/docs/specs/software-requirements/srd003-crumbs-interface.yaml
@@ -1,9 +1,9 @@
-id: "prd003-crumbs-interface"
+id: "srd003-crumbs-interface"
 title: Crumbs Interface
 problem: |
-  Applications need to create, retrieve, and manage individual work items (crumbs). prd001-cupboard-core defines the Cupboard interface with uniform Table access, but it does not specify the Crumb entity structure, entity methods, or how crumbs interact with the Table interface. Without this specification, implementations will make inconsistent decisions about field names, state transitions, and property handling.
+  Applications need to create, retrieve, and manage individual work items (crumbs). srd001-cupboard-core defines the Cupboard interface with uniform Table access, but it does not specify the Crumb entity structure, entity methods, or how crumbs interact with the Table interface. Without this specification, implementations will make inconsistent decisions about field names, state transitions, and property handling.
 
-  This PRD defines the Crumb entity: the struct fields, entity methods for state management and property access, and how crumbs are stored and retrieved via the Table interface. Trail membership is not stored on the Crumb; the links table (prd002-sqlite-backend) handles belongs_to relationships.
+  This SRD defines the Crumb entity: the struct fields, entity methods for state management and property access, and how crumbs are stored and retrieved via the Table interface. Trail membership is not stored on the Crumb; the links table (srd002-sqlite-backend) handles belongs_to relationships.
 goals:
 - G1: Define the Crumb struct with all required fields
 - G2: Define state values and their meaning
@@ -41,7 +41,7 @@ requirements:
         weight: 2
     - R1.4:
         text: "Trail membership is not a Crumb field. Use the links table (belongs_to link type) to associate crumbs with\
-          \ trails. See prd002-sqlite-backend"
+          \ trails. See srd002-sqlite-backend"
         weight: 1
     - R1.5:
         text: "CreatedAt and UpdatedAt must be set to the current time on creation. UpdatedAt must be updated on any modification\
@@ -76,7 +76,7 @@ requirements:
     - R3.2:
         text: "When Table.Set is called with an empty ID, the backend must generate a UUID v7 for CrumbID, set State to \"\
           draft\", set CreatedAt to now, set UpdatedAt to now, and initialize Properties map with all defined properties set\
-          \ to their type-based default values (see prd004-properties-interface R3.5)"
+          \ to their type-based default values (see srd004-properties-interface R3.5)"
         weight: 2
     - R3.4:
         text: "Table.Set must validate that Name is non-empty and return ErrInvalidName if empty"
@@ -244,14 +244,14 @@ package_contract:
   import_constraints:
   - pkg/schema must not import pkg/api or internal/
 non_goals:
-- "This PRD does not define the Table interface or Cupboard interface. See prd001-cupboard-core"
-- "This PRD does not define trail operations. See prd006-trails-interface"
-- "This PRD does not define property definitions. See prd004-properties-interface"
-- This PRD does not define complex state transition rules beyond Pebble validation. Applications may add additional validation
+- "This SRD does not define the Table interface or Cupboard interface. See srd001-cupboard-core"
+- "This SRD does not define trail operations. See srd006-trails-interface"
+- "This SRD does not define property definitions. See srd004-properties-interface"
+- This SRD does not define complex state transition rules beyond Pebble validation. Applications may add additional validation
   logic
-- "This PRD does not define batch operations (e.g., bulk dust, bulk update)"
-- "This PRD does not define full-text search on crumb names or content"
-- This PRD does not define property validation at the entity method level. Property methods may defer validation to Table.Set
+- "This SRD does not define batch operations (e.g., bulk dust, bulk update)"
+- "This SRD does not define full-text search on crumb names or content"
+- This SRD does not define property validation at the entity method level. Property methods may defer validation to Table.Set
   for simplicity
 acceptance_criteria:
 - id: AC1

--- a/docs/specs/software-requirements/srd004-properties-interface.yaml
+++ b/docs/specs/software-requirements/srd004-properties-interface.yaml
@@ -1,13 +1,13 @@
-id: "prd004-properties-interface"
+id: "srd004-properties-interface"
 title: Properties Interface
 problem: |
   Applications need extensible attributes on crumbs beyond the core fields (name, state, timestamps). A task tracker might need priority, labels, and owner; a bug tracker might need severity and component. Hardcoding these fields into the Crumb struct creates rigid schemas that require code changes and migrations for every new attribute.
 
   We need a property system where applications can define custom attributes at runtime. Properties are metadata definitions (name, type, description) that can then be assigned values on individual crumbs. This separates schema (what properties exist) from data (what values crumbs have), enabling flexibility without migrations.
 
-  This PRD defines the Property and Category entities: their struct fields and entity methods. Properties and categories are stored and retrieved via the generic Table interface from prd001-cupboard-core. Setting and getting property values on crumbs is handled by Crumb entity methods (see prd003-crumbs-interface); this PRD covers only the property definitions themselves.
+  This SRD defines the Property and Category entities: their struct fields and entity methods. Properties and categories are stored and retrieved via the generic Table interface from srd001-cupboard-core. Setting and getting property values on crumbs is handled by Crumb entity methods (see srd003-crumbs-interface); this SRD covers only the property definitions themselves.
 
-  Future scope: VISION.md establishes that properties are a general mechanism extending crumbs, trails, and stashes uniformly. This PRD specifies crumb properties for the current release. Trail properties (e.g., hypothesis, approach, risk-level for exploration sessions) and stash properties (e.g., build-stage, artifact-type, retention-policy for shared state) will follow the same pattern in later releases.
+  Future scope: VISION.md establishes that properties are a general mechanism extending crumbs, trails, and stashes uniformly. This SRD specifies crumb properties for the current release. Trail properties (e.g., hypothesis, approach, risk-level for exploration sessions) and stash properties (e.g., build-stage, artifact-type, retention-policy for shared state) will follow the same pattern in later releases.
 goals:
 - G1: Define the Property struct with all required fields
 - G2: Define the Category struct for categorical properties
@@ -77,7 +77,7 @@ requirements:
         text: "ValueType is stored as a string, not an enum, for JSON compatibility"
         weight: 1
     - R3.3:
-        text: "Crumb.SetProperty validates that values match the property's ValueType (see prd003-crumbs-interface R5)"
+        text: "Crumb.SetProperty validates that values match the property's ValueType (see srd003-crumbs-interface R5)"
         weight: 1
     - R3.4:
         text: "For categorical properties, values must be valid CategoryIDs defined for that property"
@@ -109,7 +109,7 @@ requirements:
     - R4.4:
         text: The backfill SELECT in step 3 must use the same transaction as the INSERT in step 2. This prevents a race where
           a crumb is created after the SELECT but before the commit (the newly created crumb will receive the property default
-          via the crumb creation path in prd003 R3.2).
+          via the crumb creation path in srd003 R3.2).
         weight: 5
     - R4.5:
         text: "Property initialization on existing crumbs (backfill) is atomic with property creation. If backfill fails,\
@@ -247,16 +247,16 @@ package_contract:
   import_constraints:
   - pkg/schema must not import pkg/api or internal/
 non_goals:
-- "This PRD does not define setting or getting property values on crumbs. See prd003-crumbs-interface for SetProperty, GetProperty,\
+- "This SRD does not define setting or getting property values on crumbs. See srd003-crumbs-interface for SetProperty, GetProperty,\
   \ GetProperties, and ClearProperty"
-- This PRD does not define property deletion. Properties are permanent once defined. Applications can stop using a property
+- This SRD does not define property deletion. Properties are permanent once defined. Applications can stop using a property
   but cannot remove its definition
-- "This PRD does not define property modification (renaming, changing type). Properties are immutable after creation"
-- This PRD does not define property inheritance or computed properties
-- "This PRD does not define validation rules beyond type checking (e.g., regex patterns, min/max values)"
-- "This PRD does not define a specialized PropertyTable interface. Properties and categories are accessed via the standard\
-  \ Table interface from prd001-cupboard-core"
-- "This PRD does not define incremental or resumable backfill. If the process crashes during backfill, the next Attach reloads\
+- "This SRD does not define property modification (renaming, changing type). Properties are immutable after creation"
+- This SRD does not define property inheritance or computed properties
+- "This SRD does not define validation rules beyond type checking (e.g., regex patterns, min/max values)"
+- "This SRD does not define a specialized PropertyTable interface. Properties and categories are accessed via the standard\
+  \ Table interface from srd001-cupboard-core"
+- "This SRD does not define incremental or resumable backfill. If the process crashes during backfill, the next Attach reloads\
   \ from JSONL (source of truth) and the rollback ensures JSONL reflects only committed state"
 acceptance_criteria:
 - id: AC1

--- a/docs/specs/software-requirements/srd005-metadata-interface.yaml
+++ b/docs/specs/software-requirements/srd005-metadata-interface.yaml
@@ -1,11 +1,11 @@
-id: "prd005-metadata-interface"
+id: "srd005-metadata-interface"
 title: Metadata Interface
 problem: |
   Applications need to attach supplementary information to crumbs beyond structured properties. A developer might add comments during work, attach log files for debugging, or link to external resources. Properties handle typed, single-value attributes; metadata handles unstructured, multi-value content like comments, attachments, and activity logs.
 
   Hardcoding metadata types (comments table, attachments table) creates rigid schemas. Applications should be able to define new metadata types through schema registration without code changes. A plugin might add "reviews" or "time_entries" as new metadata types.
 
-  prd001-cupboard-core defines the Cupboard interface with uniform Table access, but it does not specify the Metadata entity structure or how metadata interacts with the Table interface. This PRD defines the Metadata entity: the struct fields, schema registration for extensible metadata tables, and how metadata is stored and retrieved via the Table interface.
+  srd001-cupboard-core defines the Cupboard interface with uniform Table access, but it does not specify the Metadata entity structure or how metadata interacts with the Table interface. This SRD defines the Metadata entity: the struct fields, schema registration for extensible metadata tables, and how metadata is stored and retrieved via the Table interface.
 goals:
 - G1: Define the Metadata struct with all required fields
 - G2: Define the Schema struct for metadata table schema registration
@@ -216,14 +216,14 @@ requirements:
         text: All errors must be checkable with errors.Is
         weight: 1
 non_goals:
-- "This PRD does not define the Table interface or Cupboard interface. See prd001-cupboard-core."
-- "This PRD does not define crumb operations. See prd003-crumbs-interface."
-- "This PRD does not define property definitions. See prd004-properties-interface."
-- This PRD does not define file storage for attachments. The attachments schema stores references; actual file handling is
+- "This SRD does not define the Table interface or Cupboard interface. See srd001-cupboard-core."
+- "This SRD does not define crumb operations. See srd003-crumbs-interface."
+- "This SRD does not define property definitions. See srd004-properties-interface."
+- This SRD does not define file storage for attachments. The attachments schema stores references; actual file handling is
   outside this scope.
-- "This PRD does not define full-text search indexing. The content_contains filter is substring matching, not ranked search."
-- "This PRD does not define schema enforcement. ContentType is advisory; content is stored as-is."
-- "This PRD does not define batch operations for metadata (e.g., bulk add, bulk delete)."
+- "This SRD does not define full-text search indexing. The content_contains filter is substring matching, not ranked search."
+- "This SRD does not define schema enforcement. ContentType is advisory; content is stored as-is."
+- "This SRD does not define batch operations for metadata (e.g., bulk add, bulk delete)."
 acceptance_criteria:
 - id: AC1
   criterion: "Metadata struct defined with MetadataID, CrumbID, TableName, Content, PropertyID, CreatedAt"

--- a/docs/specs/software-requirements/srd006-trails-interface.yaml
+++ b/docs/specs/software-requirements/srd006-trails-interface.yaml
@@ -1,11 +1,11 @@
-id: "prd006-trails-interface"
+id: "srd006-trails-interface"
 title: Trails Interface
 problem: |
   Applications need to support exploratory work sessions where users can try different approaches without committing to them permanently. A developer might start working on a feature, explore multiple implementation paths, and later decide to keep some work while discarding dead ends. Without trails, all crumbs are permanent from the moment of creation, making exploratory workflows awkward or impossible.
 
   We need a way to group crumbs into exploratory sessions (trails) that can later be committed (made permanent) or abandoned (discarded entirely). This enables backtracking and branching without cluttering the main work stream with abandoned attempts.
 
-  This PRD defines the Trail entity: its struct fields and entity methods for lifecycle operations (Complete, Abandon). Entity methods update the Trail struct in memory; the caller persists changes via Table.Set, at which point the backend performs cascade operations (removing links or deleting crumbs). Trail membership is stored via the links table (belongs_to relationship); this PRD specifies the semantics while prd002-sqlite-backend specifies the storage.
+  This SRD defines the Trail entity: its struct fields and entity methods for lifecycle operations (Complete, Abandon). Entity methods update the Trail struct in memory; the caller persists changes via Table.Set, at which point the backend performs cascade operations (removing links or deleting crumbs). Trail membership is stored via the links table (belongs_to relationship); this SRD specifies the semantics while srd002-sqlite-backend specifies the storage.
 goals:
 - G1: Define the Trail struct with all required fields
 - G2: Define trail states and their meaning
@@ -176,7 +176,7 @@ requirements:
         text: All errors must be checkable with errors.Is
         weight: 1
     - R8.3:
-        text: "Table operations (Get, Set, Fetch) may return additional errors as defined in prd001-cupboard-core R7"
+        text: "Table operations (Get, Set, Fetch) may return additional errors as defined in srd001-cupboard-core R7"
         weight: 1
   R9:
     title: Trail Branching
@@ -213,15 +213,15 @@ package_contract:
   import_constraints:
   - pkg/schema must not import pkg/api or internal/
 non_goals:
-- "This PRD does not define crumb CRUD operations. See prd003-crumbs-interface."
-- "This PRD does not define the Table interface or link storage. The Table interface is defined in prd001-cupboard-core and\
-  \ the links table is detailed in prd002-sqlite-backend. This PRD defines entity methods that use those interfaces."
-- This PRD does not define nested trails or trail hierarchies. Each trail is independent.
-- This PRD does not define undo for Complete or Abandon. These are terminal operations.
-- "This PRD does not define batch operations on trails (e.g., merge trails, split trails)."
-- "This PRD does not define a specialized TrailTable interface. Trails are accessed via the standard Table interface from\
-  \ prd001-cupboard-core."
-- This PRD does not define entity methods for adding or removing crumbs from trails. Crumb membership is managed via the links
+- "This SRD does not define crumb CRUD operations. See srd003-crumbs-interface."
+- "This SRD does not define the Table interface or link storage. The Table interface is defined in srd001-cupboard-core and\
+  \ the links table is detailed in srd002-sqlite-backend. This SRD defines entity methods that use those interfaces."
+- This SRD does not define nested trails or trail hierarchies. Each trail is independent.
+- This SRD does not define undo for Complete or Abandon. These are terminal operations.
+- "This SRD does not define batch operations on trails (e.g., merge trails, split trails)."
+- "This SRD does not define a specialized TrailTable interface. Trails are accessed via the standard Table interface from\
+  \ srd001-cupboard-core."
+- This SRD does not define entity methods for adding or removing crumbs from trails. Crumb membership is managed via the links
   table using the standard Table interface.
 acceptance_criteria:
 - id: AC1

--- a/docs/specs/software-requirements/srd007-links-interface.yaml
+++ b/docs/specs/software-requirements/srd007-links-interface.yaml
@@ -1,16 +1,16 @@
-id: "prd007-links-interface"
+id: "srd007-links-interface"
 title: Links Interface
 problem: |
-  Links represent directed edges in the entity graph. They connect crumbs to trails (belongs_to), crumbs to crumbs (child_of), trails to crumbs (branches_from), and stashes to trails (scoped_to). Link requirements are currently scattered across four PRDs (prd002-sqlite-backend, prd006-trails-interface, prd008-stash-interface, prd003-crumbs-interface), making it difficult to understand the complete link behavior and constraints.
+  Links represent directed edges in the entity graph. They connect crumbs to trails (belongs_to), crumbs to crumbs (child_of), trails to crumbs (branches_from), and stashes to trails (scoped_to). Link requirements are currently scattered across four SRDs (srd002-sqlite-backend, srd006-trails-interface, srd008-stash-interface, srd003-crumbs-interface), making it difficult to understand the complete link behavior and constraints.
 
-  We consolidate all link requirements into one authoritative source. Other PRDs should reference prd007-links-interface for link behavior rather than duplicating these specifications. The Link entity is the only entity without a dedicated interface PRD; prd007 fills that gap.
+  We consolidate all link requirements into one authoritative source. Other SRDs should reference srd007-links-interface for link behavior rather than duplicating these specifications. The Link entity is the only entity without a dedicated interface SRD; srd007 fills that gap.
 goals:
 - G1: Define the Link struct with all required fields
 - G2: Define valid link types and their semantics
 - G3: Document CRUD operations via the Table interface
 - G4: Define filter keys and query semantics
 - G5: Document uniqueness constraint and indexes
-- G6: Consolidate cardinality rules from other PRDs
+- G6: Consolidate cardinality rules from other SRDs
 - G7: Document error handling
 - G8: Define graph audit functions for integrity validation
 requirements:
@@ -157,11 +157,11 @@ requirements:
         text: "Audit functions are also available as Cupboard methods for on-demand validation"
         weight: 8
 non_goals:
-- "This PRD does not define cascade behavior on trail completion or abandonment. See prd006-trails-interface for cascade semantics"
-- "This PRD does not define entity-specific query patterns (e.g., finding all crumbs in a trail). Those patterns are documented\
-  \ in the entity-specific PRDs"
-- This PRD does not define link update operations. Links are immutable; delete and recreate to modify
-- This PRD does not change the existing Link implementation
+- "This SRD does not define cascade behavior on trail completion or abandonment. See srd006-trails-interface for cascade semantics"
+- "This SRD does not define entity-specific query patterns (e.g., finding all crumbs in a trail). Those patterns are documented\
+  \ in the entity-specific SRDs"
+- This SRD does not define link update operations. Links are immutable; delete and recreate to modify
+- This SRD does not change the existing Link implementation
 acceptance_criteria:
 - id: AC1
   criterion: "Link struct defined with LinkID, LinkType, FromID, ToID, CreatedAt"
@@ -209,7 +209,7 @@ acceptance_criteria:
   - R5.4
   - R5.5
 - id: AC8
-  criterion: Cardinality rules consolidated from other PRDs
+  criterion: Cardinality rules consolidated from other SRDs
   traces:
   - R6.1
   - R6.2

--- a/docs/specs/software-requirements/srd008-stash-interface.yaml
+++ b/docs/specs/software-requirements/srd008-stash-interface.yaml
@@ -1,11 +1,11 @@
-id: "prd008-stash-interface"
+id: "srd008-stash-interface"
 title: Stash Interface
 problem: |
   Crumbs are individual work items. Trails group them. But there is no mechanism for crumbs to share runtime state. When multiple agents coordinate on related tasks, they need shared resources (files, URLs, connections), artifacts (outputs from one crumb as inputs to another), context (decisions, configuration), and coordination primitives (locks, counters).
 
   Without shared state, agents must pass information through external channels or encode it in crumb properties, which conflates task attributes with coordination state. We need a dedicated entity for shared state that is scoped to a trail (or global), versioned, and auditable.
 
-  This PRD defines the Stash entity: the struct fields, stash types, entity methods for value management and coordination, and how stashes interact with the Table interface.
+  This SRD defines the Stash entity: the struct fields, stash types, entity methods for value management and coordination, and how stashes interact with the Table interface.
 goals:
 - G1: Define the Stash struct with all required fields
 - G2: Define stash types and their semantics
@@ -267,12 +267,12 @@ package_contract:
   import_constraints:
   - pkg/schema must not import pkg/api or internal/
 non_goals:
-- This PRD does not define queue or channel stash types. These may be added in a future version
-- "This PRD does not define stash replication or cross-cupboard sharing"
-- This PRD does not define TTL or automatic expiration for stashes
-- This PRD does not define access control or permissions on stashes
-- This PRD does not define history compaction or pruning. History grows unbounded
-- This PRD does not define blocking lock acquisition with timeout. Callers implement retry loops
+- This SRD does not define queue or channel stash types. These may be added in a future version
+- "This SRD does not define stash replication or cross-cupboard sharing"
+- This SRD does not define TTL or automatic expiration for stashes
+- This SRD does not define access control or permissions on stashes
+- This SRD does not define history compaction or pruning. History grows unbounded
+- This SRD does not define blocking lock acquisition with timeout. Callers implement retry loops
 acceptance_criteria:
 - id: AC1
   criterion: "Stash struct defined with StashID, Name, StashType, Value, Version, CreatedAt fields"

--- a/docs/specs/software-requirements/srd009-cupboard-cli.yaml
+++ b/docs/specs/software-requirements/srd009-cupboard-cli.yaml
@@ -1,7 +1,7 @@
-id: "prd009-cupboard-cli"
+id: "srd009-cupboard-cli"
 title: Cupboard CLI Interface
 problem: |
-  The CLI design is scattered across multiple documents. prd001-cupboard-core defines the Cupboard and Table interfaces but does not specify CLI commands. prd010-configuration-directories defines configuration flags but not command structure. prd003-crumbs-interface defines the Crumb entity but not crumb-specific CLI commands. eng02-beads-migration lists issue-tracking commands but not their full specification.
+  The CLI design is scattered across multiple documents. srd001-cupboard-core defines the Cupboard and Table interfaces but does not specify CLI commands. srd010-configuration-directories defines configuration flags but not command structure. srd003-crumbs-interface defines the Crumb entity but not crumb-specific CLI commands. eng02-beads-migration lists issue-tracking commands but not their full specification.
 
   Agents building the CLI must read four documents and infer the CLI contract. Without a single specification, implementations diverge on command naming, flag conventions, output formats, and error handling. We need one document that defines the complete CLI interface so developers and agents can implement commands consistently.
 goals:
@@ -185,7 +185,7 @@ requirements:
         text: Init must create empty JSONL files if they do not exist
         weight: 2
     - R10.4:
-        text: "Init must seed built-in properties (priority, type, description, owner, labels) per prd004-properties-interface\
+        text: "Init must seed built-in properties (priority, type, description, owner, labels) per srd004-properties-interface\
           \ R8"
         weight: 5
     - R10.5:
@@ -195,12 +195,12 @@ requirements:
         text: "Init must print \"Cupboard initialized successfully\" on completion"
         weight: 1
 non_goals:
-- This PRD does not define a graphical user interface (GUI) or terminal user interface (TUI)
-- "This PRD does not define shell completion scripts (bash, zsh, fish)"
-- This PRD does not define a plugin system for custom commands
-- "This PRD does not define remote backend support (HTTP, gRPC)"
-- This PRD does not define batch operations beyond what the generic table commands provide
-- This PRD does not define interactive mode or REPL functionality
+- This SRD does not define a graphical user interface (GUI) or terminal user interface (TUI)
+- "This SRD does not define shell completion scripts (bash, zsh, fish)"
+- This SRD does not define a plugin system for custom commands
+- "This SRD does not define remote backend support (HTTP, gRPC)"
+- This SRD does not define batch operations beyond what the generic table commands provide
+- This SRD does not define interactive mode or REPL functionality
 acceptance_criteria:
 - id: AC1
   criterion: "All implemented commands documented (init, version, get, set, delete, list, crumb add/get/list/delete)"

--- a/docs/specs/software-requirements/srd010-configuration-directories.yaml
+++ b/docs/specs/software-requirements/srd010-configuration-directories.yaml
@@ -1,4 +1,4 @@
-id: "prd010-configuration-directories"
+id: "srd010-configuration-directories"
 title: Configuration Directory Structure
 problem: |
   The Cupboard CLI needs two distinct directory locations: one for application settings (backend selection, defaults) and one for backend data (crumbs, trails, links). These serve different purposes and have different lifecycles. Configuration is set once and rarely changes; data changes constantly. Separating them clarifies what to version-control versus what to treat as runtime state, and simplifies backup strategies.
@@ -110,7 +110,7 @@ requirements:
     title: Write Operations
     items:
     - R6.1:
-        text: "Write operations persist to JSONL according to the sync strategy defined in prd002-sqlite-backend R16 (immediate,\
+        text: "Write operations persist to JSONL according to the sync strategy defined in srd002-sqlite-backend R16 (immediate,\
           \ on_close, or batch)"
         weight: 3
     - R6.2:
@@ -164,11 +164,11 @@ requirements:
           a Config struct to pass to Attach
         weight: 1
 non_goals:
-- This PRD does not define configuration file encryption or secrets management.
-- "This PRD does not define multi-workspace support (multiple data directories). One CLI instance operates on one data directory\
+- This SRD does not define configuration file encryption or secrets management.
+- "This SRD does not define multi-workspace support (multiple data directories). One CLI instance operates on one data directory\
   \ at a time."
-- "This PRD does not define network-based configuration (e.g., fetching config from a server)."
-- This PRD does not define Windows support.
+- "This SRD does not define network-based configuration (e.g., fetching config from a server)."
+- This SRD does not define Windows support.
 acceptance_criteria:
 - id: AC1
   criterion: CLI configuration directory default and override mechanism defined

--- a/docs/specs/software-requirements/srd011-blazes-templates.yaml
+++ b/docs/specs/software-requirements/srd011-blazes-templates.yaml
@@ -1,4 +1,4 @@
-id: "prd011-blazes-templates"
+id: "srd011-blazes-templates"
 title: "Blazes Template Schema, Discovery, and Selection"
 problem: |
   Coding agents frequently encounter tasks that follow recognizable patterns: fixing a bug, implementing
@@ -14,11 +14,11 @@ problem: |
   the workflow structure (which crumbs to create, their dependencies, their trail organization) so agents
   start from a known-good pattern instead of improvising.
 
-  This PRD defines the blaze template system: the YAML schema for template files, the mechanism for
+  This SRD defines the blaze template system: the YAML schema for template files, the mechanism for
   discovering templates on the filesystem, the algorithm for matching a task to a template via tags, the
   selection logic when multiple templates match, and the extraction of parameters that the agent or user
   must supply before instantiation. Template instantiation (actually creating trails, crumbs, and links
-  from a template) is out of scope and deferred to a future PRD (prd-blazes-instantiation).
+  from a template) is out of scope and deferred to a future SRD (srd-blazes-instantiation).
 goals:
 - G1: Define the Blaze template YAML schema with required and optional fields
 - G2: Define the BlazeParameter schema for template parameters
@@ -68,12 +68,12 @@ requirements:
         text: "The parameters field is optional. When omitted or empty, the template requires no user input before instantiation"
         weight: 1
     - R1.9:
-        text: "The trail_definition field is optional in this PRD. Its schema will be defined in prd-blazes-instantiation.\
+        text: "The trail_definition field is optional in this SRD. Its schema will be defined in srd-blazes-instantiation.\
           \ Discovery and selection ignore this field entirely"
         weight: 1
     - R1.10:
         text: Unknown fields in the template YAML must be ignored (forward compatibility). The parser must not reject a template
-          because it contains fields not defined in this PRD
+          because it contains fields not defined in this SRD
         weight: 1
     - R1.11:
         text: |
@@ -118,7 +118,7 @@ requirements:
               type: integer
               default: 3
           trail_definition:
-            # Defined in prd-blazes-instantiation
+            # Defined in srd-blazes-instantiation
           ```
         weight: 1
   R2:
@@ -186,7 +186,7 @@ requirements:
           3. Well-known path: `.crumbs/blazes/` relative to the Cupboard data directory (Config.DataDir)
         weight: 1
     - R3.3:
-        text: "The well-known path `.crumbs/blazes/` is relative to the data directory resolved by prd010-configuration-directories.\
+        text: "The well-known path `.crumbs/blazes/` is relative to the data directory resolved by srd010-configuration-directories.\
           \ For example, if DataDir is `/project/.crumbs-db`, the well-known template path is `/project/.crumbs-db/.crumbs/blazes/`"
         weight: 3
     - R3.4:
@@ -230,7 +230,7 @@ requirements:
         weight: 1
     - R5.2:
         text: "Parsing must not read or interpret the trail_definition field. This field is opaque during discovery and selection,\
-          \ reserved for instantiation (prd-blazes-instantiation)"
+          \ reserved for instantiation (srd-blazes-instantiation)"
         weight: 1
     - R5.3:
         text: "If a template file contains invalid YAML (syntax error), the parser must skip that file, record a warning with\
@@ -403,7 +403,7 @@ requirements:
     title: Error Handling
     items:
     - R9.1:
-        text: "Blaze template operations must use the following sentinel errors, following the pattern established in prd001-cupboard-core\
+        text: "Blaze template operations must use the following sentinel errors, following the pattern established in srd001-cupboard-core\
           \ R7"
         weight: 1
     - R9.2:
@@ -448,20 +448,20 @@ requirements:
           \ as warnings. The parser skips the unreadable file and continues with remaining files"
         weight: 1
 non_goals:
-- "This PRD does not define trail instantiation from templates. Creating trails, crumbs, and belongs_to links from a selected\
-  \ template is deferred to prd-blazes-instantiation"
-- "This PRD does not define parameter value binding or placeholder expansion. Substituting parameter values into trail definitions\
-  \ is deferred to prd-blazes-instantiation"
-- "This PRD does not define creating crumbs via Table.Set (prd003-crumbs-interface R3) from template data. That requires instantiation"
-- "This PRD does not define creating trails via Table.Set (prd006-trails-interface R3) from template data. That requires instantiation"
-- "This PRD does not define creating belongs_to links (prd006-trails-interface R7) from template data. That requires instantiation"
-- This PRD does not define template versioning or inheritance. Templates are standalone files; there is no mechanism for one
+- "This SRD does not define trail instantiation from templates. Creating trails, crumbs, and belongs_to links from a selected\
+  \ template is deferred to srd-blazes-instantiation"
+- "This SRD does not define parameter value binding or placeholder expansion. Substituting parameter values into trail definitions\
+  \ is deferred to srd-blazes-instantiation"
+- "This SRD does not define creating crumbs via Table.Set (srd003-crumbs-interface R3) from template data. That requires instantiation"
+- "This SRD does not define creating trails via Table.Set (srd006-trails-interface R3) from template data. That requires instantiation"
+- "This SRD does not define creating belongs_to links (srd006-trails-interface R7) from template data. That requires instantiation"
+- This SRD does not define template versioning or inheritance. Templates are standalone files; there is no mechanism for one
   template to extend or override another
-- This PRD does not define remote template repositories. Templates are local filesystem files only
-- This PRD does not define template creation or editing workflows. Templates are authored manually or by external tools
-- "This PRD does not define a specialized BlazeTable interface. Blaze operations are standalone functions, not part of the\
+- This SRD does not define remote template repositories. Templates are local filesystem files only
+- This SRD does not define template creation or editing workflows. Templates are authored manually or by external tools
+- "This SRD does not define a specialized BlazeTable interface. Blaze operations are standalone functions, not part of the\
   \ Table interface"
-- This PRD does not define Go struct definitions. Go structs will be defined in a subsequent code task. This PRD specifies
+- This SRD does not define Go struct definitions. Go structs will be defined in a subsequent code task. This SRD specifies
   the contract
 acceptance_criteria:
 - id: AC1

--- a/docs/specs/software-requirements/srd012-branch-independent-data.yaml
+++ b/docs/specs/software-requirements/srd012-branch-independent-data.yaml
@@ -1,4 +1,4 @@
-id: "prd012-branch-independent-data"
+id: "srd012-branch-independent-data"
 title: "Branch-Independent Data Persistence"
 problem: |
   The beads model tied issue state to git branches. JSONL files traveled with task branches,
@@ -24,7 +24,7 @@ requirements:
         text: "The data directory must be a fixed path, not scoped to any git branch or worktree"
         weight: 1
     - R1.2:
-        text: "The data directory path must be determined by configuration (see prd010-configuration-directories), not by\
+        text: "The data directory path must be determined by configuration (see srd010-configuration-directories), not by\
           \ the current branch name or worktree path"
         weight: 1
     - R1.3:
@@ -74,11 +74,11 @@ requirements:
         text: "Traceability from an issue to commits is achieved via git log --grep=\"<crumb-id>\", searching across all branches"
         weight: 1
 non_goals:
-- "This PRD does not define how agents create or manage code branches for development work. Branch conventions for code are\
-  \ outside this PRD's scope."
-- "This PRD does not define CI/CD pipelines, remote synchronization, or push behavior."
-- "This PRD does not change the JSONL format, SQLite schema, or Cupboard interface."
-- This PRD does not prohibit committing JSONL changes alongside code changes on the same commit; it requires only that JSONL
+- "This SRD does not define how agents create or manage code branches for development work. Branch conventions for code are\
+  \ outside this SRD's scope."
+- "This SRD does not define CI/CD pipelines, remote synchronization, or push behavior."
+- "This SRD does not change the JSONL format, SQLite schema, or Cupboard interface."
+- This SRD does not prohibit committing JSONL changes alongside code changes on the same commit; it requires only that JSONL
   not be isolated to task branches.
 acceptance_criteria:
 - id: AC1

--- a/docs/specs/software-requirements/srd013-table-query-helpers.yaml
+++ b/docs/specs/software-requirements/srd013-table-query-helpers.yaml
@@ -1,4 +1,4 @@
-id: "prd013-table-query-helpers"
+id: "srd013-table-query-helpers"
 title: Table Query Helpers
 problem: |
   Every table accessor in the SQLite backend (crumbs, trails, links, stashes, properties,
@@ -109,10 +109,10 @@ requirements:
           \ the current entity's ID)"
         weight: 2
 non_goals:
-- "This PRD does not define entity-specific hydration logic. Each table accessor still defines its own hydration function;\
-  \ this PRD provides the Scanner interface they accept"
-- This PRD does not define transaction management. Transaction begin/commit/rollback remains in each table accessor
-- This PRD does not define JSONL persistence helpers. JSONL operations remain in the engine package
+- "This SRD does not define entity-specific hydration logic. Each table accessor still defines its own hydration function;\
+  \ this SRD provides the Scanner interface they accept"
+- This SRD does not define transaction management. Transaction begin/commit/rollback remains in each table accessor
+- This SRD does not define JSONL persistence helpers. JSONL operations remain in the engine package
 acceptance_criteria:
 - id: AC1
   criterion: "Package lives at internal/persistence/queryutil with no dependency on pkg/schema, engine, or mapping; table\

--- a/docs/specs/software-requirements/srd014-entity-lifecycle-helpers.yaml
+++ b/docs/specs/software-requirements/srd014-entity-lifecycle-helpers.yaml
@@ -1,4 +1,4 @@
-id: "prd014-entity-lifecycle-helpers"
+id: "srd014-entity-lifecycle-helpers"
 title: Entity Lifecycle Helpers
 problem: |
   Every table accessor in the SQLite backend repeats the same entity creation scaffolding:
@@ -87,11 +87,11 @@ requirements:
           \ metadata, and links within the same transaction)"
         weight: 5
 non_goals:
-- "This PRD does not define JSONL persistence after commit. Table accessors handle JSONL writes after the transaction completes,\
+- "This SRD does not define JSONL persistence after commit. Table accessors handle JSONL writes after the transaction completes,\
   \ since JSONL file selection varies by entity type"
-- "This PRD does not define cascade logic. Cascade operations (trail complete/abandon) remain in the table accessor's callback\
+- "This SRD does not define cascade logic. Cascade operations (trail complete/abandon) remain in the table accessor's callback\
   \ functions"
-- "This PRD does not define entity-specific validation. Name validation, state transition checks, and type assertions remain\
+- "This SRD does not define entity-specific validation. Name validation, state transition checks, and type assertions remain\
   \ in each table accessor"
 acceptance_criteria:
 - id: AC1

--- a/docs/specs/test-suites/test-rel01.0.yaml
+++ b/docs/specs/test-suites/test-rel01.0.yaml
@@ -7,13 +7,13 @@ traces:
 - rel01.0-uc003-crumb-lifecycle
 - rel01.0-uc004-scaffolding-validation
 - rel01.0-uc005-crumbs-table-benchmarks
-- prd001-cupboard-core R1, R2, R2.5, R3, R4, R5, R6, R7
-- prd002-sqlite-backend R3.3, R4, R5, R6, R14, R15, R16
-- prd003-crumbs-interface R1, R2, R3, R4, R5, R9, R10
-- prd004-properties-interface R1
-- prd005-metadata-interface R1
-- prd006-trails-interface R1
-- prd008-stash-interface R1
+- srd001-cupboard-core R1, R2, R2.5, R3, R4, R5, R6, R7
+- srd002-sqlite-backend R3.3, R4, R5, R6, R14, R15, R16
+- srd003-crumbs-interface R1, R2, R3, R4, R5, R9, R10
+- srd004-properties-interface R1
+- srd005-metadata-interface R1
+- srd006-trails-interface R1
+- srd008-stash-interface R1
 preconditions:
 - Cupboard binary built from cmd/cupboard
 - Fresh temp directory for config and data
@@ -82,7 +82,7 @@ test_cases:
     exit_code: 0
 - name: Full lifecycle with crumbs and trails
   description: 'Create 3 crumbs, transition crumb1 to pebble, create 2 trails, link crumb2 to trail1 and crumb3 to trail2,
-    complete trail1, abandon trail2. Per prd006-trails-interface R5.6/R6.6: completing trail1 removes belongs_to links (crumb2
+    complete trail1, abandon trail2. Per srd006-trails-interface R5.6/R6.6: completing trail1 removes belongs_to links (crumb2
     becomes permanent), abandoning trail2 deletes crumb3. '
   inputs: {}
   expected:
@@ -520,7 +520,7 @@ test_cases:
     stdout: cupboard
 - name: Crumb struct has required fields
   description: 'Compile-time test. Instantiate a Crumb with all documented fields to verify the struct definition matches
-    prd003-crumbs-interface. '
+    srd003-crumbs-interface. '
   inputs: {}
   expected: {}
 - name: Trail struct has required fields
@@ -651,7 +651,7 @@ test_cases:
     stdout: BenchmarkCrumbsGet10000_UC005
 - name: Set create benchmark with 10 existing crumbs
   description: 'Measure Table.Set latency for creating new crumbs (empty ID triggers UUID v7 generation). Seeds 10 existing
-    crumbs before measuring create operations per prd002-sqlite-backend R5.3. '
+    crumbs before measuring create operations per srd002-sqlite-backend R5.3. '
   inputs:
     args:
     - go test -bench=BenchmarkCrumbsSetCreate10_UC005 -benchmem ./tests/integration/...
@@ -714,7 +714,7 @@ test_cases:
     stdout: BenchmarkCrumbsFetchAll1000_UC005
 - name: Fetch with state filter benchmark 100 crumbs
   description: 'Measure Table.Fetch with state filter (State: draft). Seeds 100 crumbs cycling through draft, pending, ready
-    states. Exercises idx_crumbs_state index per prd002-sqlite-backend R3.3. '
+    states. Exercises idx_crumbs_state index per srd002-sqlite-backend R3.3. '
   inputs:
     args:
     - go test -bench=BenchmarkCrumbsFetchState100_UC005 -benchmem ./tests/integration/...

--- a/docs/specs/test-suites/test-rel01.1.yaml
+++ b/docs/specs/test-suites/test-rel01.1.yaml
@@ -7,11 +7,11 @@ traces:
 - rel01.1-uc003-configuration-loading
 - rel01.1-uc004-generic-table-cli
 - rel01.1-uc005-flat-self-hosting
-- prd001-cupboard-core R1, R2, R3, R4
-- prd002-sqlite-backend R1, R1.2, R4, R5, R5.2, R14, R16.1, R16.2, R16.3, R16.4, R16.5, R16.6
-- prd003-crumbs-interface R1
-- prd009-cupboard-cli R3, R3.1, R3.2, R3.3, R3.4, R6.2, R6.3, R7, R8, R9
-- prd010-configuration-directories R1, R1.2, R1.3, R2, R2.2, R2.3, R7
+- srd001-cupboard-core R1, R2, R3, R4
+- srd002-sqlite-backend R1, R1.2, R4, R5, R5.2, R14, R16.1, R16.2, R16.3, R16.4, R16.5, R16.6
+- srd003-crumbs-interface R1
+- srd009-cupboard-cli R3, R3.1, R3.2, R3.3, R3.4, R6.2, R6.3, R7, R8, R9
+- srd010-configuration-directories R1, R1.2, R1.3, R2, R2.2, R2.3, R7
 preconditions:
 - Go toolchain installed (version 1.25 or later)
 - $GOBIN is in $PATH (typically ~/go/bin)
@@ -81,7 +81,7 @@ test_cases:
     exit_code: 0
     stdout: get
 - name: Init creates data directory
-  description: 'Running cupboard init in a project directory creates the data directory. The directory layout follows prd010-configuration-directories
+  description: 'Running cupboard init in a project directory creates the data directory. The directory layout follows srd010-configuration-directories
     R2. '
   inputs:
     args:
@@ -226,7 +226,7 @@ test_cases:
     exit_code: 0
     stdout: '[''created_at'', ''T'']'
 - name: JSONL uses lowercase hyphenated UUIDs
-  description: 'UUID v7 identifiers should be lowercase with hyphens per prd002-sqlite-backend R2.12. '
+  description: 'UUID v7 identifiers should be lowercase with hyphens per srd002-sqlite-backend R2.12. '
   inputs:
     args:
     - cat data/crumbs.jsonl
@@ -239,7 +239,7 @@ test_cases:
   expected:
     exit_code: 1
 - name: Cupboard command regenerates database from JSONL
-  description: 'After deleting cupboard.db, running any cupboard command should trigger the startup sequence (prd002-sqlite-backend
+  description: 'After deleting cupboard.db, running any cupboard command should trigger the startup sequence (srd002-sqlite-backend
     R4) which recreates the database. '
   inputs:
     args:
@@ -311,7 +311,7 @@ test_cases:
   expected:
     exit_code: 0
 - name: Fresh start with no files
-  description: 'When no data directory exists, cupboard should create it and initialize empty JSONL files per prd002-sqlite-backend
+  description: 'When no data directory exists, cupboard should create it and initialize empty JSONL files per srd002-sqlite-backend
     R1.3, R1.4. '
   inputs:
     args:

--- a/docs/specs/test-suites/test-rel02.0.yaml
+++ b/docs/specs/test-suites/test-rel02.0.yaml
@@ -4,10 +4,10 @@ release: '02.0'
 traces:
 - rel02.0-uc001-property-enforcement
 - rel02.0-uc002-regeneration-compatibility
-- prd001-cupboard-core R2, R3, R4, R5
-- prd002-sqlite-backend R2, R4, R5, R7.2, R9
-- prd003-crumbs-interface R3, R5
-- prd004-properties-interface R2, R4, R7, R8, R9
+- srd001-cupboard-core R2, R3, R4, R5
+- srd002-sqlite-backend R2, R4, R5, R7.2, R9
+- srd003-crumbs-interface R3, R5
+- srd004-properties-interface R2, R4, R7, R8, R9
 preconditions:
 - Cupboard binary built from cmd/cupboard
 - Fresh temp directory for config and data

--- a/docs/specs/test-suites/test-rel02.1.yaml
+++ b/docs/specs/test-suites/test-rel02.1.yaml
@@ -6,11 +6,11 @@ traces:
 - rel02.1-uc002-table-benchmarks
 - rel02.1-uc003-self-hosting
 - rel02.1-uc004-metadata-lifecycle
-- prd001-cupboard-core R2, R3, R3.2, R3.3
-- prd002-sqlite-backend R1, R2, R2.8, R3, R3.3, R4, R5, R5.2, R12, R13, R14, R15, R16, R16.2
-- prd003-crumbs-interface R1, R2, R3, R4, R4.3, R5, R9, R10
-- prd004-properties-interface R9
-- prd005-metadata-interface R1, R3, R4, R5, R6.5, R7, R10
+- srd001-cupboard-core R2, R3, R3.2, R3.3
+- srd002-sqlite-backend R1, R2, R2.8, R3, R3.3, R4, R5, R5.2, R12, R13, R14, R15, R16, R16.2
+- srd003-crumbs-interface R1, R2, R3, R4, R4.3, R5, R9, R10
+- srd004-properties-interface R9
+- srd005-metadata-interface R1, R3, R4, R5, R6.5, R7, R10
 preconditions:
 - Cupboard binary built from cmd/cupboard
 - Fresh temp directory for config and data
@@ -20,7 +20,7 @@ preconditions:
 - Go test infrastructure available (go test command)
 - tests/integration package contains benchmark test files
 - Cupboard initialized with SQLite backend in a temp directory
-- Built-in properties seeded per prd002-sqlite-backend R9
+- Built-in properties seeded per srd002-sqlite-backend R9
 - No existing crumbs
 - Cupboard attached with SQLite backend
 - Fresh temp directory for data
@@ -252,7 +252,7 @@ test_cases:
     stdout: BenchmarkCrumbsGet10000
 - name: Set create benchmark with 10 existing crumbs
   description: 'Measure Table.Set latency for creating new crumbs (empty ID triggers UUID v7 generation). Includes JSONL sync
-    cost per prd002-sqlite-backend R5.3. '
+    cost per srd002-sqlite-backend R5.3. '
   inputs:
     args:
     - go test -bench=BenchmarkCrumbsSetCreate10 -benchmem ./tests/integration/...
@@ -267,7 +267,7 @@ test_cases:
     exit_code: 0
     stdout: BenchmarkCrumbsSetCreate1000
 - name: Set update benchmark with 10 crumbs
-  description: 'Measure Table.Set latency for updating existing crumbs. Includes JSONL sync cost per prd002-sqlite-backend
+  description: 'Measure Table.Set latency for updating existing crumbs. Includes JSONL sync cost per srd002-sqlite-backend
     R5.3. '
   inputs:
     args:
@@ -283,7 +283,7 @@ test_cases:
     exit_code: 0
     stdout: BenchmarkCrumbsSetUpdate1000
 - name: Delete benchmark with 10 crumbs
-  description: 'Measure Table.Delete latency including cascade deletion of property values, metadata, and links per prd003-crumbs-interface
+  description: 'Measure Table.Delete latency including cascade deletion of property values, metadata, and links per srd003-crumbs-interface
     R8.3. Each iteration creates then deletes a crumb. '
   inputs:
     args:
@@ -315,7 +315,7 @@ test_cases:
     exit_code: 0
     stdout: BenchmarkCrumbsFetchAll1000
 - name: Fetch with state filter benchmark 100 crumbs
-  description: 'Measure Table.Fetch with state filter. Exercises idx_crumbs_state index per prd002-sqlite-backend R3.3. '
+  description: 'Measure Table.Fetch with state filter. Exercises idx_crumbs_state index per srd002-sqlite-backend R3.3. '
   inputs:
     args:
     - go test -bench=BenchmarkCrumbsFetchState100 -benchmem ./tests/integration/...

--- a/docs/specs/test-suites/test-rel03.0.yaml
+++ b/docs/specs/test-suites/test-rel03.0.yaml
@@ -6,11 +6,11 @@ traces:
 - rel03.0-uc002-link-management
 - rel03.0-uc003-stash-operations
 - rel03.0-uc004-trail-crumb-lifecycle
-- prd001-cupboard-core R2, R3
-- prd002-sqlite-backend R3.3, R12, R13, R14.6
-- prd006-trails-interface R2, R3, R5, R5.6, R6, R6.6, R6.7, R7, R9
-- prd007-links-interface R2.1, R3, R4, R6.1
-- prd008-stash-interface R1, R1.6, R2, R4, R5, R6, R7, R9, R13
+- srd001-cupboard-core R2, R3
+- srd002-sqlite-backend R3.3, R12, R13, R14.6
+- srd006-trails-interface R2, R3, R5, R5.6, R6, R6.6, R6.7, R7, R9
+- srd007-links-interface R2.1, R3, R4, R6.1
+- srd008-stash-interface R1, R1.6, R2, R4, R5, R6, R7, R9, R13
 preconditions:
 - Cupboard initialized with SQLite backend
 - trails, crumbs, and links tables accessible via GetTable
@@ -21,7 +21,7 @@ preconditions:
 - No existing stashes in the database
 test_cases:
 - name: Create trail defaults to draft state
-  description: When no state is provided, new trails default to draft state per prd006-trails-interface R2.2
+  description: When no state is provided, new trails default to draft state per srd006-trails-interface R2.2
   inputs:
     args:
     - 'trail := &Trail{CreatedAt: time.Now()} trailsTable.Set("", trail) '

--- a/docs/specs/test-suites/test-rel03.1.yaml
+++ b/docs/specs/test-suites/test-rel03.1.yaml
@@ -3,10 +3,10 @@ title: Post-Trails Validation
 release: '03.1'
 traces:
 - rel03.1-uc001-self-hosting-with-epics
-- prd001-cupboard-core R2, R3
-- prd002-sqlite-backend R1, R2, R3, R4, R5
-- prd006-trails-interface R2, R5, R6
-- prd007-links-interface R2.1
+- srd001-cupboard-core R2, R3
+- srd002-sqlite-backend R1, R2, R3, R4, R5
+- srd006-trails-interface R2, R5, R6
+- srd007-links-interface R2.1
 preconditions:
 - Cupboard initialized with SQLite backend
 - No existing crumbs, trails, or links in the database

--- a/docs/specs/test-suites/test-rel04.0.yaml
+++ b/docs/specs/test-suites/test-rel04.0.yaml
@@ -3,9 +3,9 @@ title: Branch-Independent Data Persistence
 release: "04.0"
 traces:
   - rel04.0-uc001-branch-independent-data
-  - prd002-sqlite-backend R4, R1.1
-  - prd010-configuration-directories R1, R2
-  - prd012-branch-independent-data R1.1, R1.2, R1.4, R2.1, R2.2, R2.3, R3.3, R4.1
+  - srd002-sqlite-backend R4, R1.1
+  - srd010-configuration-directories R1, R2
+  - srd012-branch-independent-data R1.1, R1.2, R1.4, R2.1, R2.2, R2.3, R3.3, R4.1
 preconditions:
   - Git repository initialized with cupboard configured
   - data directory path set in config; cupboard.db in .gitignore

--- a/docs/specs/test-suites/test-rel99.0.yaml
+++ b/docs/specs/test-suites/test-rel99.0.yaml
@@ -4,12 +4,12 @@ release: '99.0'
 traces:
 - rel99.0-uc001-blazes-templates
 - rel99.0-uc002-docker-bootstrap
-- prd001-cupboard-core R1, R2, R3, R4, R5
-- prd002-sqlite-backend R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16
-- prd003-crumbs-interface R1, R4, R5
-- prd006-trails-interface R3
-- prd010-configuration-directories R1, R2, R3, R4, R7, R8
-- prd011-blazes-templates R1, R4, R5, R6, R7, R8
+- srd001-cupboard-core R1, R2, R3, R4, R5
+- srd002-sqlite-backend R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16
+- srd003-crumbs-interface R1, R4, R5
+- srd006-trails-interface R3
+- srd010-configuration-directories R1, R2, R3, R4, R7, R8
+- srd011-blazes-templates R1, R4, R5, R6, R7, R8
 preconditions:
 - Template directory exists at .crumbs/blazes/ or configured path
 - At least one valid template YAML file in the directory
@@ -17,7 +17,7 @@ preconditions:
 - Agent has access to task context for semantic matching
 - Docker installed and running on host
 - Claude API access available (ANTHROPIC_API_KEY set)
-- docs/ directory contains VISION.md, ARCHITECTURE.md, road-map.yaml, PRDs, use cases
+- docs/ directory contains VISION.md, ARCHITECTURE.md, road-map.yaml, SRDs, use cases
 - No crumbs source code in container (only docs/ mounted)
 test_cases:
 - name: Discover template directory at well-known path
@@ -193,10 +193,10 @@ test_cases:
   expected:
     exit_code: 0
     stdout: releases
-- name: Read all PRDs in product-requirements
+- name: Read all SRDs in software-requirements
   inputs:
     args:
-    - ls /workspace/docs/specs/product-requirements/prd*.yaml | wc -l
+    - ls /workspace/docs/specs/software-requirements/srd*.yaml | wc -l
   expected:
     exit_code: 0
 - name: Create pkg/types directory structure
@@ -205,7 +205,7 @@ test_cases:
     - 'mkdir -p /workspace/pkg/types mkdir -p /workspace/internal/sqlite mkdir -p /workspace/cmd/crumbs '
   expected:
     exit_code: 0
-- name: Implement Cupboard interface per prd001-cupboard-core
+- name: Implement Cupboard interface per srd001-cupboard-core
   inputs:
     args:
     - 'Agent implements pkg/types/cupboard.go with: - Cupboard interface (Attach, Detach, GetTable) - Table interface (Get,
@@ -312,18 +312,18 @@ test_cases:
     - ./crumbs update ${item_id} --state ready
   expected:
     exit_code: 0
-- name: Verify Cupboard interface matches prd001-cupboard-core
+- name: Verify Cupboard interface matches srd001-cupboard-core
   inputs:
     args:
     - 'Inspect pkg/types/cupboard.go Verify Attach, Detach, GetTable methods present Verify Table interface has Get, Set,
       Delete, Fetch '
   expected: {}
-- name: Verify Crumb struct matches prd003-crumbs-interface
+- name: Verify Crumb struct matches srd003-crumbs-interface
   inputs:
     args:
-    - 'Inspect pkg/types/crumb.go Verify all fields from prd003-crumbs-interface R1 '
+    - 'Inspect pkg/types/crumb.go Verify all fields from srd003-crumbs-interface R1 '
   expected: {}
-- name: Verify SQLite backend matches prd002-sqlite-backend
+- name: Verify SQLite backend matches srd002-sqlite-backend
   inputs:
     args:
     - 'Inspect internal/sqlite/*.go Verify JSONL format, directory layout, startup loading '

--- a/docs/specs/use-cases/rel01.0-uc001-cupboard-lifecycle.yaml
+++ b/docs/specs/use-cases/rel01.0-uc001-cupboard-lifecycle.yaml
@@ -4,7 +4,7 @@ summary: |
   An application initializes a Cupboard with a typed Config struct, attaches
   to a SQLite backend, accesses tables for data operations, and detaches to
   release resources. This tracer bullet validates the configuration workflow
-  and cupboard lifecycle management defined in prd001-cupboard-core.
+  and cupboard lifecycle management defined in srd001-cupboard-core.
 actor: Developer integrating the Crumbs library into their application
 trigger: Application startup requiring backend connection and data operations
 flow:
@@ -19,30 +19,30 @@ flow:
   - F9: "Detach from backend (after F8 completes): when the application shuts down call Detach(); blocks until in-flight operations complete then closes database connections"
   - F10: "Verify detach (after F9): after Detach any Cupboard operation returns ErrCupboardDetached; the application must create a new Cupboard instance to reconnect"
 touchpoints:
-  - T1: "Config struct: construction with Backend and DataDir fields (prd001-cupboard-core R1)"
-  - T2: "Cupboard interface: Attach, Detach, GetTable (prd001-cupboard-core R2)"
-  - T3: "Table interface: Fetch for connection verification (prd001-cupboard-core R2)"
-  - T4: "Attach idempotency and validation (prd001-cupboard-core R4)"
-  - T5: "Detach resource release and idempotency (prd001-cupboard-core R5)"
-  - T6: "Error handling after detach (prd001-cupboard-core R6)"
-  - T7: "Standard error types: ErrAlreadyAttached, ErrCupboardDetached, ErrTableNotFound (prd001-cupboard-core R7)"
+  - T1: "Config struct: construction with Backend and DataDir fields (srd001-cupboard-core R1)"
+  - T2: "Cupboard interface: Attach, Detach, GetTable (srd001-cupboard-core R2)"
+  - T3: "Table interface: Fetch for connection verification (srd001-cupboard-core R2)"
+  - T4: "Attach idempotency and validation (srd001-cupboard-core R4)"
+  - T5: "Detach resource release and idempotency (srd001-cupboard-core R5)"
+  - T6: "Error handling after detach (srd001-cupboard-core R6)"
+  - T7: "Standard error types: ErrAlreadyAttached, ErrCupboardDetached, ErrTableNotFound (srd001-cupboard-core R7)"
 success_criteria:
   - id: S1
     criterion: Full attach-operate-detach lifecycle completes without error; Config with Backend=sqlite produces a working Cupboard, GetTable returns a Table, a Fetch operation on that Table succeeds, and Detach releases resources
     traces:
-      - prd001-cupboard-core AC1
-      - prd001-cupboard-core AC5
-      - prd001-cupboard-core AC6
+      - srd001-cupboard-core AC1
+      - srd001-cupboard-core AC5
+      - srd001-cupboard-core AC6
   - id: S2
     criterion: After Detach, all Cupboard and Table operations return ErrCupboardDetached; the sentinel is checkable with errors.Is
     traces:
-      - prd001-cupboard-core AC6
-      - prd001-cupboard-core AC7
+      - srd001-cupboard-core AC6
+      - srd001-cupboard-core AC7
   - id: S3
     criterion: Error boundaries enforce lifecycle state; Attach on an already-attached cupboard returns ErrAlreadyAttached, and GetTable for an unknown table name returns ErrTableNotFound
     traces:
-      - prd001-cupboard-core AC5
-      - prd001-cupboard-core AC7
+      - srd001-cupboard-core AC5
+      - srd001-cupboard-core AC7
 out_of_scope:
   - Connection pooling or retry policies
   - File-based configuration loading (JSON/YAML parsing)

--- a/docs/specs/use-cases/rel01.0-uc002-table-crud.yaml
+++ b/docs/specs/use-cases/rel01.0-uc002-table-crud.yaml
@@ -28,32 +28,32 @@ flow:
   - F15: "Repeat on every standard table (same contract as F3-F13): for each of trails, properties, metadata, links, and stashes, call cupboard.GetTable(name), create an entity with Set (empty ID), retrieve it with Get, list with Fetch, and delete with Delete; the same Table interface contract holds across all six standard tables"
   - F16: "Detach (after all operations complete): call cupboard.Detach() to release resources; subsequent Table operations return ErrCupboardDetached"
 touchpoints:
-  - T1: "Cupboard interface: Attach, GetTable, Detach (prd001-cupboard-core R2)"
-  - T2: "Table interface: Get, Set, Delete, Fetch (prd001-cupboard-core R2)"
-  - T3: "SQLite backend: UUID v7 generation, hydration, dehydration, JSONL persistence (prd002-sqlite-backend R5, R14)"
-  - T4: "Table.Set with empty ID generates UUID v7 and creates entity (prd002-sqlite-backend R5)"
-  - T5: "Table.Get retrieves and hydrates entity from SQLite (prd002-sqlite-backend R14)"
-  - T6: "Table.Fetch returns matching entities; empty filter returns all (prd001-cupboard-core R2)"
-  - T7: "Table.Delete removes entity from SQLite and JSONL (prd002-sqlite-backend R5)"
-  - T8: "JSONL files are human-readable and reflect all write operations (prd002-sqlite-backend R5, R16)"
+  - T1: "Cupboard interface: Attach, GetTable, Detach (srd001-cupboard-core R2)"
+  - T2: "Table interface: Get, Set, Delete, Fetch (srd001-cupboard-core R2)"
+  - T3: "SQLite backend: UUID v7 generation, hydration, dehydration, JSONL persistence (srd002-sqlite-backend R5, R14)"
+  - T4: "Table.Set with empty ID generates UUID v7 and creates entity (srd002-sqlite-backend R5)"
+  - T5: "Table.Get retrieves and hydrates entity from SQLite (srd002-sqlite-backend R14)"
+  - T6: "Table.Fetch returns matching entities; empty filter returns all (srd001-cupboard-core R2)"
+  - T7: "Table.Delete removes entity from SQLite and JSONL (srd002-sqlite-backend R5)"
+  - T8: "JSONL files are human-readable and reflect all write operations (srd002-sqlite-backend R5, R16)"
 success_criteria:
   - id: S1
     criterion: Full CRUD round-trip completes; Set with empty ID creates an entity with UUID v7, Get retrieves it with all fields matching, Set with existing ID updates it, Get confirms the change, Delete removes it, and subsequent Get returns ErrNotFound
     traces:
-      - prd001-cupboard-core AC3
-      - prd002-sqlite-backend AC1
-      - prd002-sqlite-backend AC4
+      - srd001-cupboard-core AC3
+      - srd002-sqlite-backend AC1
+      - srd002-sqlite-backend AC4
   - id: S2
     criterion: The same CRUD operations (Set, Get, Fetch, Delete) work identically on all six standard tables (crumbs, trails, properties, metadata, links, stashes); the Table interface contract is uniform across entity types
     traces:
-      - prd001-cupboard-core AC3
-      - prd001-cupboard-core AC4
-      - prd002-sqlite-backend AC11
+      - srd001-cupboard-core AC3
+      - srd001-cupboard-core AC4
+      - srd002-sqlite-backend AC11
   - id: S3
     criterion: JSONL persistence reflects all write operations; create, update, and delete are visible in the JSONL file as valid JSON lines, confirming the cross-layer path from Table interface through SQLite to JSONL
     traces:
-      - prd002-sqlite-backend AC1
-      - prd002-sqlite-backend AC4
+      - srd002-sqlite-backend AC1
+      - srd002-sqlite-backend AC4
 out_of_scope:
   - Crumb state machine transitions (SetState, Pebble, Dust) — see rel01.0-uc003
   - Entity method behavior beyond field assignment — see rel01.0-uc003

--- a/docs/specs/use-cases/rel01.0-uc003-crumb-lifecycle.yaml
+++ b/docs/specs/use-cases/rel01.0-uc003-crumb-lifecycle.yaml
@@ -25,29 +25,29 @@ flow:
   - F13: "Verify UpdatedAt tracks transitions (across all transitions in F4-F7): for each state transition confirm that UpdatedAt changed and is equal to or later than the previous value; CreatedAt must remain unchanged"
   - F14: "Detach (after all operations complete): call cupboard.Detach()"
 touchpoints:
-  - T1: "Table interface: Get, Set, Fetch for persistence and retrieval (prd001-cupboard-core R2)"
-  - T2: "Crumb entity: SetState, Pebble, Dust methods (prd003-crumbs-interface R2)"
-  - T3: "Crumb state machine: draft to pending to ready to taken to pebble; any to dust (prd003-crumbs-interface R2, R4, R5)"
-  - T4: "Crumb creation defaults to draft state with initialized timestamps (prd003-crumbs-interface R1, R3)"
-  - T5: "UpdatedAt advances on every state transition; CreatedAt remains constant (prd003-crumbs-interface R3)"
-  - T6: "State-based Fetch filtering correctly includes and excludes crumbs by state (prd003-crumbs-interface R9, R10)"
+  - T1: "Table interface: Get, Set, Fetch for persistence and retrieval (srd001-cupboard-core R2)"
+  - T2: "Crumb entity: SetState, Pebble, Dust methods (srd003-crumbs-interface R2)"
+  - T3: "Crumb state machine: draft to pending to ready to taken to pebble; any to dust (srd003-crumbs-interface R2, R4, R5)"
+  - T4: "Crumb creation defaults to draft state with initialized timestamps (srd003-crumbs-interface R1, R3)"
+  - T5: "UpdatedAt advances on every state transition; CreatedAt remains constant (srd003-crumbs-interface R3)"
+  - T6: "State-based Fetch filtering correctly includes and excludes crumbs by state (srd003-crumbs-interface R9, R10)"
 success_criteria:
   - id: S1
     criterion: Full success path (draft to pending to ready to taken to pebble) and full failure path (draft to dust) both complete, with UpdatedAt advancing on each transition and CreatedAt remaining constant throughout
     traces:
-      - prd003-crumbs-interface AC2
-      - prd003-crumbs-interface AC3
-      - prd003-crumbs-interface AC4
+      - srd003-crumbs-interface AC2
+      - srd003-crumbs-interface AC3
+      - srd003-crumbs-interface AC4
   - id: S2
     criterion: Dust() transitions a crumb to the dust terminal state from any non-terminal state (not only from draft), confirming the any-to-dust edge case in the state machine
     traces:
-      - prd003-crumbs-interface AC3
-      - prd003-crumbs-interface AC11
+      - srd003-crumbs-interface AC3
+      - srd003-crumbs-interface AC11
   - id: S3
     criterion: State-based Fetch filtering correctly partitions crumbs; filtering for a non-terminal state excludes pebble and dust crumbs, and filtering for pebble or dust returns only crumbs in that terminal state
     traces:
-      - prd003-crumbs-interface AC12
-      - prd003-crumbs-interface AC13
+      - srd003-crumbs-interface AC12
+      - srd003-crumbs-interface AC13
 out_of_scope:
   - Generic Table CRUD operations (create, update, delete, fetch) — see rel01.0-uc002
   - Property operations (SetProperty, GetProperty, ClearProperty) — see rel02.0-uc001

--- a/docs/specs/use-cases/rel01.0-uc004-scaffolding-validation.yaml
+++ b/docs/specs/use-cases/rel01.0-uc004-scaffolding-validation.yaml
@@ -20,34 +20,34 @@ flow:
   - F8: "Attach and enumerate tables (requires compiled binary and working backend from F2-F6): create a Cupboard, attach with a temporary directory, and call GetTable for each of the six standard table names; each call must return a non-nil Table without error; detach afterward"
 touchpoints:
   - T1: "go.mod: module path github.com/mesh-intelligence/crumbs with local replace directive"
-  - T2: "Cupboard interface: Attach, GetTable, Detach (prd001-cupboard-core R2)"
-  - T3: "Table interface: compile-time verification of Get, Set, Delete, Fetch signatures (prd001-cupboard-core R2)"
-  - T4: "Entity types (all 7): compile-time verification of struct fields (prd003-crumbs-interface R1)"
-  - T5: "Trail entity struct fields (prd006-trails-interface R1)"
-  - T6: "Property entity struct fields (prd004-properties-interface R1)"
-  - T7: "Stash entity struct fields (prd008-stash-interface R1)"
-  - T8: "Metadata entity struct fields (prd005-metadata-interface R1)"
-  - T9: "SQLite backend: NewBackend, Attach (schema creation), Detach (prd002-sqlite-backend R4, R6)"
+  - T2: "Cupboard interface: Attach, GetTable, Detach (srd001-cupboard-core R2)"
+  - T3: "Table interface: compile-time verification of Get, Set, Delete, Fetch signatures (srd001-cupboard-core R2)"
+  - T4: "Entity types (all 7): compile-time verification of struct fields (srd003-crumbs-interface R1)"
+  - T5: "Trail entity struct fields (srd006-trails-interface R1)"
+  - T6: "Property entity struct fields (srd004-properties-interface R1)"
+  - T7: "Stash entity struct fields (srd008-stash-interface R1)"
+  - T8: "Metadata entity struct fields (srd005-metadata-interface R1)"
+  - T9: "SQLite backend: NewBackend, Attach (schema creation), Detach (srd002-sqlite-backend R4, R6)"
   - T10: "CLI (cmd/cupboard): version command with implemented use case listing"
-  - T11: "GetTable returns a Table for all six standard table names (prd001-cupboard-core R2.5)"
+  - T11: "GetTable returns a Table for all six standard table names (srd001-cupboard-core R2.5)"
 success_criteria:
   - id: S1
     criterion: CLI binary compiles and runs; go build produces a working binary through the mesh-intelligence module path, and the version command prints a version string with implemented use case list (including this use case) and exits with code 0
     traces:
-      - prd001-cupboard-core AC2
-      - prd001-cupboard-core AC3
+      - srd001-cupboard-core AC2
+      - srd001-cupboard-core AC3
   - id: S2
     criterion: Type system is complete; all seven entity structs (Crumb, Trail, Property, Category, Stash, Metadata, Link), the Table interface (Get, Set, Delete, Fetch), and the Cupboard interface (GetTable, Attach, Detach) compile with documented signatures, and the SQLite backend satisfies the Cupboard interface at compile time
     traces:
-      - prd001-cupboard-core AC2
-      - prd001-cupboard-core AC3
-      - prd002-sqlite-backend AC11
-      - prd003-crumbs-interface AC1
+      - srd001-cupboard-core AC2
+      - srd001-cupboard-core AC3
+      - srd002-sqlite-backend AC11
+      - srd003-crumbs-interface AC1
   - id: S3
     criterion: GetTable succeeds for all six standard tables (crumbs, trails, properties, metadata, links, stashes) and returns ErrTableNotFound for unknown table names, confirming the table routing layer connects all entity types
     traces:
-      - prd001-cupboard-core AC4
-      - prd002-sqlite-backend AC12
+      - srd001-cupboard-core AC4
+      - srd002-sqlite-backend AC12
 out_of_scope:
   - Creating, retrieving, or deleting entities (see rel01.0-uc002 and rel01.0-uc003)
   - State transitions or entity methods beyond compile-time existence

--- a/docs/specs/use-cases/rel01.0-uc005-crumbs-table-benchmarks.yaml
+++ b/docs/specs/use-cases/rel01.0-uc005-crumbs-table-benchmarks.yaml
@@ -34,21 +34,21 @@ flow:
   - F17: "Run full benchmark suite (requires all benchmarks from F3-F16): execute go test -bench=. -benchmem and capture output"
   - F18: "Record baseline (requires output from F17): save benchmark output for future comparison with benchstat"
 touchpoints:
-  - T1: "Table interface: Get, Set, Delete, Fetch (prd001-cupboard-core R3)"
-  - T2: "SQLite backend: entity hydration, dehydration, JSONL persistence (prd002-sqlite-backend R14, R15)"
-  - T3: "SQLite indexes: idx_crumbs_state for state filter benchmarks (prd002-sqlite-backend R3.3)"
-  - T4: "Cupboard interface: Attach, Detach for benchmark setup/teardown (prd001-cupboard-core R2)"
+  - T1: "Table interface: Get, Set, Delete, Fetch (srd001-cupboard-core R3)"
+  - T2: "SQLite backend: entity hydration, dehydration, JSONL persistence (srd002-sqlite-backend R14, R15)"
+  - T3: "SQLite indexes: idx_crumbs_state for state filter benchmarks (srd002-sqlite-backend R3.3)"
+  - T4: "Cupboard interface: Attach, Detach for benchmark setup/teardown (srd001-cupboard-core R2)"
 success_criteria:
   - id: S1
     criterion: All benchmark functions (Get, Set create, Set update, Delete, Fetch all, Fetch with state filter) complete without error and produce ns/op, B/op, and allocs/op output, confirming the Table interface and SQLite backend operate correctly under sustained load
     traces:
-      - prd001-cupboard-core AC3
-      - prd002-sqlite-backend AC4
+      - srd001-cupboard-core AC3
+      - srd002-sqlite-backend AC4
   - id: S2
     criterion: Benchmarks cover multiple data scales (Get at 4 scales, Set/Delete/Fetch at 2 scales each), validating that the Table-to-SQLite path maintains consistent behavior as data volume increases from 10 to 10000 entities
     traces:
-      - prd002-sqlite-backend AC2
-      - prd002-sqlite-backend AC4
+      - srd002-sqlite-backend AC2
+      - srd002-sqlite-backend AC4
 out_of_scope:
   - Property operations (SetProperty, GetProperty, ClearProperty) — see rel02.0
   - Fetch with properties filter — requires rel02.0 property system

--- a/docs/specs/use-cases/rel01.1-uc001-go-install.yaml
+++ b/docs/specs/use-cases/rel01.1-uc001-go-install.yaml
@@ -19,15 +19,15 @@ flow:
   - F5: "List crumbs (requires crumb from F4): run cupboard list crumbs to confirm persistence"
 touchpoints:
   - T1: "cmd/cupboard: CLI binary built by go install"
-  - T2: "pkg/types: Config struct, entity types (prd001-cupboard-core R1)"
-  - T3: "internal/sqlite: Backend that creates JSONL files and SQLite cache (prd002-sqlite-backend R1, R4)"
-  - T4: "internal/paths: Resolves default config and data directories (prd010-configuration-directories R1, R2)"
+  - T2: "pkg/types: Config struct, entity types (srd001-cupboard-core R1)"
+  - T3: "internal/sqlite: Backend that creates JSONL files and SQLite cache (srd002-sqlite-backend R1, R4)"
+  - T4: "internal/paths: Resolves default config and data directories (srd010-configuration-directories R1, R2)"
 success_criteria:
   - id: S1
     criterion: End-to-end flow works from go install; binary installs into $GOBIN, help prints usage, init creates data directory with JSONL files, and set/list round-trips a crumb with no manual compilation steps beyond go install
     traces:
-      - prd009-cupboard-cli AC1
-      - prd010-configuration-directories AC4
+      - srd009-cupboard-cli AC1
+      - srd010-configuration-directories AC4
 out_of_scope:
   - Package managers (brew, apt, snap)
   - Docker-based installation (see rel99.0-uc002-docker-bootstrap)

--- a/docs/specs/use-cases/rel01.1-uc002-jsonl-git-roundtrip.yaml
+++ b/docs/specs/use-cases/rel01.1-uc002-jsonl-git-roundtrip.yaml
@@ -18,7 +18,7 @@ flow:
   - F4: Commit the JSONL files to git
   - F5: Verify SQLite database exists (pre-deletion baseline)
   - F6: "Delete SQLite database to simulate fresh clone or branch switch"
-  - F7: "Re-attach by running a cupboard command (triggers startup sequence from prd002 R4 to rebuild from JSONL)"
+  - F7: "Re-attach by running a cupboard command (triggers startup sequence from srd002 R4 to rebuild from JSONL)"
   - F8: "Verify all crumbs are intact (requires rebuilt database from F7)"
   - F9: "Verify queries work correctly (requires rebuilt database from F7)"
   - F10: "Modify data and verify JSONL is updated"
@@ -28,37 +28,37 @@ flow:
   - F14: "Test batch sync strategy (separate from default path): verify flush at BatchSize threshold"
   - F15: "Test immediate sync strategy (default, validated by F1-F12): verify every write persists"
 touchpoints:
-  - T1: "SQLite backend startup sequence: delete db, create schema, load JSONL (prd002-sqlite-backend R4)"
-  - T2: "SQLite backend JSONL as source of truth: cupboard.db is ephemeral (prd002-sqlite-backend R1.2)"
-  - T3: SQLite backend atomic write pattern for JSONL (prd002-sqlite-backend R5.2)
-  - T4: SQLite backend immediate sync strategy (prd002-sqlite-backend R16.2)
-  - T5: SQLite backend entity hydration from SQLite rows (prd002-sqlite-backend R14)
-  - T6: "Cupboard interface: Attach initializes backend (prd001-cupboard-core R4)"
+  - T1: "SQLite backend startup sequence: delete db, create schema, load JSONL (srd002-sqlite-backend R4)"
+  - T2: "SQLite backend JSONL as source of truth: cupboard.db is ephemeral (srd002-sqlite-backend R1.2)"
+  - T3: SQLite backend atomic write pattern for JSONL (srd002-sqlite-backend R5.2)
+  - T4: SQLite backend immediate sync strategy (srd002-sqlite-backend R16.2)
+  - T5: SQLite backend entity hydration from SQLite rows (srd002-sqlite-backend R14)
+  - T6: "Cupboard interface: Attach initializes backend (srd001-cupboard-core R4)"
   - T7: "Git integration: JSONL files committed, cupboard.db gitignored (eng01-git-integration)"
   - T8: "Git integration: Commit JSONL alongside code changes (eng01-git-integration)"
-  - T9: "SQLite backend on_close sync strategy: defer writes until Detach (prd002-sqlite-backend R16.3)"
-  - T10: "SQLite backend batch sync strategy: flush at BatchSize or BatchInterval (prd002-sqlite-backend R16.4-R16.6)"
-  - T11: "SQLite backend sync strategy dispatch: backend reads SyncStrategy from config (prd002-sqlite-backend R16.1)"
+  - T9: "SQLite backend on_close sync strategy: defer writes until Detach (srd002-sqlite-backend R16.3)"
+  - T10: "SQLite backend batch sync strategy: flush at BatchSize or BatchInterval (srd002-sqlite-backend R16.4-R16.6)"
+  - T11: "SQLite backend sync strategy dispatch: backend reads SyncStrategy from config (srd002-sqlite-backend R16.1)"
 success_criteria:
   - id: S1
     criterion: Full git roundtrip completes; crumbs created via CLI persist to JSONL, JSONL committed to git, cupboard.db deleted, and all data is intact after re-attach — confirming JSONL is the source of truth and the startup sequence rebuilds state correctly
     traces:
-      - prd002-sqlite-backend AC1
-      - prd002-sqlite-backend AC3
-      - prd010-configuration-directories AC5
+      - srd002-sqlite-backend AC1
+      - srd002-sqlite-backend AC3
+      - srd010-configuration-directories AC5
   - id: S2
     criterion: Data survives multiple delete-rebuild cycles; state changes made between roundtrips persist through repeated database deletions, confirming the roundtrip is repeatable
     traces:
-      - prd002-sqlite-backend AC3
-      - prd002-sqlite-backend AC4
+      - srd002-sqlite-backend AC3
+      - srd002-sqlite-backend AC4
   - id: S3
     criterion: All three sync strategies (immediate, on_close, batch) produce correct JSONL for git commit; immediate persists every write, on_close defers until Detach, and batch flushes at the BatchSize threshold
     traces:
-      - prd002-sqlite-backend AC16
+      - srd002-sqlite-backend AC16
 out_of_scope:
   - Merge conflict resolution when JSONL files diverge between branches (eng01-git-integration describes this but not validated here)
   - Trail-scoped worktrees (eng01-git-integration Trails as Worktrees)
-  - Corrupt JSONL recovery (prd002-sqlite-backend R7 describes error handling but this use case assumes valid files)
-  - Cross-process access (prd002-sqlite-backend R8.5 explicitly does not support this)
+  - Corrupt JSONL recovery (srd002-sqlite-backend R7 describes error handling but this use case assumes valid files)
+  - Cross-process access (srd002-sqlite-backend R8.5 explicitly does not support this)
   - Batch interval timer edge cases (rapid attach/detach cycles, timer races)
 test_suite: test-rel01.1

--- a/docs/specs/use-cases/rel01.1-uc003-configuration-loading.yaml
+++ b/docs/specs/use-cases/rel01.1-uc003-configuration-loading.yaml
@@ -4,9 +4,9 @@ summary: 'The CLI loads configuration using a multi-layer precedence chain: plat
 
   defaults, environment variable overrides, config.yaml values, and CLI flag overrides.
 
-  This tracer bullet validates the config loading pipeline from prd010-configuration-directories
+  This tracer bullet validates the config loading pipeline from srd010-configuration-directories
 
-  and prd009-cupboard-cli, ensuring developers can control where config and data live.
+  and srd009-cupboard-cli, ensuring developers can control where config and data live.
 
   '
 actor: Developer running the cupboard CLI on Linux, macOS, or Windows
@@ -21,24 +21,24 @@ flow:
   - F7: "Pass resolved paths to Cupboard (requires both directories from F3 and F5): construct Config struct with Backend and DataDir, call Attach"
   - F8: "Verify operations work (requires attached Cupboard from F7): run a command that exercises the resolved paths (e.g., cupboard init, cupboard list crumbs)"
 touchpoints:
-  - T1: "internal/paths.DefaultConfigDir: platform-specific config directory (prd010-configuration-directories R1.2)"
-  - T2: "internal/paths.DefaultDataDir: platform-specific data directory (prd010-configuration-directories R2.2)"
-  - T3: "internal/paths.ResolveConfigDir: flag > env > default precedence (prd010-configuration-directories R1.3)"
-  - T4: "internal/paths.ResolveDataDir: flag > config > default precedence (prd010-configuration-directories R2.3)"
-  - T5: "cmd/cupboard/config.loadConfig: Viper-based config loading (prd010-configuration-directories R7)"
-  - T6: Global flags --config-dir and --data-dir (prd009-cupboard-cli R6.2, R6.3)
+  - T1: "internal/paths.DefaultConfigDir: platform-specific config directory (srd010-configuration-directories R1.2)"
+  - T2: "internal/paths.DefaultDataDir: platform-specific data directory (srd010-configuration-directories R2.2)"
+  - T3: "internal/paths.ResolveConfigDir: flag > env > default precedence (srd010-configuration-directories R1.3)"
+  - T4: "internal/paths.ResolveDataDir: flag > config > default precedence (srd010-configuration-directories R2.3)"
+  - T5: "cmd/cupboard/config.loadConfig: Viper-based config loading (srd010-configuration-directories R7)"
+  - T6: Global flags --config-dir and --data-dir (srd009-cupboard-cli R6.2, R6.3)
 success_criteria:
   - id: S1
     criterion: Full precedence chain resolves correctly for both config and data directories; flag overrides environment variable, environment variable overrides config.yaml, config.yaml overrides platform default
     traces:
-      - prd010-configuration-directories AC1
-      - prd010-configuration-directories AC2
-      - prd010-configuration-directories AC8
+      - srd010-configuration-directories AC1
+      - srd010-configuration-directories AC2
+      - srd010-configuration-directories AC8
   - id: S2
     criterion: First-run experience works without pre-existing configuration; missing config.yaml uses defaults, config directory is created if absent, and CLI operations succeed immediately
     traces:
-      - prd010-configuration-directories AC1
-      - prd010-configuration-directories AC8
+      - srd010-configuration-directories AC1
+      - srd010-configuration-directories AC8
 out_of_scope:
   - Configuration file encryption or secrets management
   - Multi-workspace support (multiple data directories)

--- a/docs/specs/use-cases/rel01.1-uc004-generic-table-cli.yaml
+++ b/docs/specs/use-cases/rel01.1-uc004-generic-table-cli.yaml
@@ -23,30 +23,30 @@ flow:
   - F7: "Handle invalid JSON (tested on F2): set returns exit code 1 with parse error details"
   - F8: "Handle invalid filter (tested on F3): list returns exit code 1 with expected key=value message"
 touchpoints:
-  - T1: "Cupboard interface: GetTable returns Table for any standard table name (prd001-cupboard-core R2)"
-  - T2: "Table interface: Get, Set, Delete, Fetch operations (prd001-cupboard-core R3)"
-  - T3: "cmd/cupboard/get.go: retrieves entity by ID, outputs JSON (prd009-cupboard-cli R3.1)"
-  - T4: "cmd/cupboard/set.go: creates or updates entity from JSON input (prd009-cupboard-cli R3.2)"
-  - T5: "cmd/cupboard/list.go: queries with key=value filters, outputs JSON array (prd009-cupboard-cli R3.4)"
-  - T6: "cmd/cupboard/delete.go: removes entity by ID (prd009-cupboard-cli R3.3)"
-  - T7: "Error handling: exit codes and message format (prd009-cupboard-cli R8, R9)"
-  - T8: "Output format: JSON with 2-space indentation (prd009-cupboard-cli R7)"
+  - T1: "Cupboard interface: GetTable returns Table for any standard table name (srd001-cupboard-core R2)"
+  - T2: "Table interface: Get, Set, Delete, Fetch operations (srd001-cupboard-core R3)"
+  - T3: "cmd/cupboard/get.go: retrieves entity by ID, outputs JSON (srd009-cupboard-cli R3.1)"
+  - T4: "cmd/cupboard/set.go: creates or updates entity from JSON input (srd009-cupboard-cli R3.2)"
+  - T5: "cmd/cupboard/list.go: queries with key=value filters, outputs JSON array (srd009-cupboard-cli R3.4)"
+  - T6: "cmd/cupboard/delete.go: removes entity by ID (srd009-cupboard-cli R3.3)"
+  - T7: "Error handling: exit codes and message format (srd009-cupboard-cli R8, R9)"
+  - T8: "Output format: JSON with 2-space indentation (srd009-cupboard-cli R7)"
 success_criteria:
   - id: S1
     criterion: Full CRUD cycle works through the CLI; set creates with generated ID, get retrieves as JSON, set updates, list returns filtered results, delete removes — all with correct exit codes (0 for success, 1 for errors)
     traces:
-      - prd009-cupboard-cli AC3
-      - prd009-cupboard-cli AC8
+      - srd009-cupboard-cli AC3
+      - srd009-cupboard-cli AC8
   - id: S2
     criterion: All generic table commands (get, set, list, delete) work identically across crumbs, trails, and links table types, confirming the CLI's uniform table routing
     traces:
-      - prd009-cupboard-cli AC3
-      - prd001-cupboard-core AC4
+      - srd009-cupboard-cli AC3
+      - srd001-cupboard-core AC4
   - id: S3
     criterion: Error handling is consistent across all commands; unknown table names, missing entities, invalid JSON, and malformed filters all produce exit code 1 with descriptive messages on stderr
     traces:
-      - prd009-cupboard-cli AC8
-      - prd009-cupboard-cli AC9
+      - srd009-cupboard-cli AC8
+      - srd009-cupboard-cli AC9
 out_of_scope:
   - Entity-specific commands with friendly flags (cupboard crumb add --name)
   - Human-readable table output (only JSON output tested)

--- a/docs/specs/use-cases/rel01.1-uc005-flat-self-hosting.yaml
+++ b/docs/specs/use-cases/rel01.1-uc005-flat-self-hosting.yaml
@@ -25,10 +25,10 @@ flow:
   - F8: "Integrate make-work.sh script (exercises F2-F3): use cupboard commands to list existing issues and create new ones"
   - F9: "Commit JSONL files to git (after F7/F8 complete): per eng01-git-integration, JSONL files are committed as part of session completion"
 touchpoints:
-  - T1: "cupboard CLI (cmd/cupboard): generic table commands get, set, list, delete (prd009-cupboard-cli R3)"
-  - T2: "Cupboard library (pkg/types): Cupboard interface with GetTable, Table interface for CRUD (prd001-cupboard-core R2, R3)"
-  - T3: "SQLite backend (internal/sqlite): storage, JSONL persistence, query engine (prd002-sqlite-backend R1-R5)"
-  - T4: "Crumb entity (pkg/types): Name, State, CreatedAt, UpdatedAt fields (prd003-crumbs-interface R1)"
+  - T1: "cupboard CLI (cmd/cupboard): generic table commands get, set, list, delete (srd009-cupboard-cli R3)"
+  - T2: "Cupboard library (pkg/types): Cupboard interface with GetTable, Table interface for CRUD (srd001-cupboard-core R2, R3)"
+  - T3: "SQLite backend (internal/sqlite): storage, JSONL persistence, query engine (srd002-sqlite-backend R1-R5)"
+  - T4: "Crumb entity (pkg/types): Name, State, CreatedAt, UpdatedAt fields (srd003-crumbs-interface R1)"
   - T5: "do-work.sh: task picking (list with filter), worktree management, agent invocation"
   - T6: "make-work.sh: work creation (set with empty ID), issue listing"
   - T7: ".claude/rules/: agent workflow instructions (eng01-git-integration)"
@@ -36,13 +36,13 @@ success_criteria:
   - id: S1
     criterion: do-work.sh completes a full cycle (pick draft task, claim by setting state to taken, close by setting state to pebble) using only generic table commands, confirming that cupboard serves as a working issue tracker for agent workflows
     traces:
-      - prd009-cupboard-cli AC3
-      - prd003-crumbs-interface AC2
+      - srd009-cupboard-cli AC3
+      - srd003-crumbs-interface AC2
   - id: S2
     criterion: make-work.sh creates issues via cupboard commands and the resulting JSONL files can be committed to git, confirming the create-and-commit workflow for agent task creation
     traces:
-      - prd009-cupboard-cli AC3
-      - prd002-sqlite-backend AC1
+      - srd009-cupboard-cli AC3
+      - srd002-sqlite-backend AC1
 out_of_scope:
   - Properties (type, priority, labels, description) - see rel02.0
   - Issue-tracking CLI commands (ready, create, update, close) - see rel02.1-uc003

--- a/docs/specs/use-cases/rel02.0-uc001-property-enforcement.yaml
+++ b/docs/specs/use-cases/rel02.0-uc001-property-enforcement.yaml
@@ -28,42 +28,42 @@ flow:
   - F18: "Verify value type validation (requires text property from F2): Attempt to call DefineCategory on a text property. Verify ErrInvalidValueType is returned."
   - F19: "Detach the cupboard: Call cupboard.Detach()."
 touchpoints:
-  - T1: "Cupboard interface: Attach, Detach, GetTable (prd001-cupboard-core R2)"
-  - T2: "Table (crumbs): Get, Set, Fetch (prd001-cupboard-core R3)"
-  - T3: "Table (properties): Get, Set, Fetch (prd001-cupboard-core R3)"
-  - T4: "Crumb entity: SetProperty, GetProperty, GetProperties, ClearProperty (prd003-crumbs-interface R5)"
-  - T5: "Property entity: struct fields, DefineCategory, GetCategories (prd004-properties-interface R7, R8)"
-  - T6: "Built-in property seeding (prd004-properties-interface R9, prd002-sqlite-backend R9)"
-  - T7: "Crumb creation with property auto-initialization (prd003-crumbs-interface R3)"
-  - T8: "Property definition with backfill to existing crumbs (prd004-properties-interface R4)"
-  - T9: "Category entity: struct fields, persistence to SQLite and JSONL (prd004-properties-interface R2, R7)"
+  - T1: "Cupboard interface: Attach, Detach, GetTable (srd001-cupboard-core R2)"
+  - T2: "Table (crumbs): Get, Set, Fetch (srd001-cupboard-core R3)"
+  - T3: "Table (properties): Get, Set, Fetch (srd001-cupboard-core R3)"
+  - T4: "Crumb entity: SetProperty, GetProperty, GetProperties, ClearProperty (srd003-crumbs-interface R5)"
+  - T5: "Property entity: struct fields, DefineCategory, GetCategories (srd004-properties-interface R7, R8)"
+  - T6: "Built-in property seeding (srd004-properties-interface R9, srd002-sqlite-backend R9)"
+  - T7: "Crumb creation with property auto-initialization (srd003-crumbs-interface R3)"
+  - T8: "Property definition with backfill to existing crumbs (srd004-properties-interface R4)"
+  - T9: "Category entity: struct fields, persistence to SQLite and JSONL (srd004-properties-interface R2, R7)"
 success_criteria:
   - id: S1
     criterion: Property auto-initialization works on crumb creation and post-definition backfill; a crumb created after Attach has all built-in properties with defaults, and a crumb created before a custom property definition receives the new property via backfill
     traces:
-      - prd004-properties-interface AC5
-      - prd003-crumbs-interface AC7
+      - srd004-properties-interface AC5
+      - srd003-crumbs-interface AC7
   - id: S2
     criterion: Property CRUD round-trips correctly; SetProperty persists a value retrievable by GetProperty, ClearProperty resets to the default (not null), and GetProperties returns the full set after each mutation
     traces:
-      - prd003-crumbs-interface AC5
-      - prd003-crumbs-interface AC6
+      - srd003-crumbs-interface AC5
+      - srd003-crumbs-interface AC6
   - id: S3
     criterion: GetProperties never returns a partial set; at every point in the flow (after creation, after backfill, after set, after clear) every crumb has exactly as many properties as are defined, with no gaps
     traces:
-      - prd004-properties-interface AC5
-      - prd003-crumbs-interface AC5
+      - srd004-properties-interface AC5
+      - srd003-crumbs-interface AC5
   - id: S4
     criterion: Category operations enforce constraints; DefineCategory creates ordered categories retrievable via GetCategories, ErrDuplicateName rejects duplicate names within a property, and ErrInvalidValueType rejects category operations on non-categorical properties
     traces:
-      - prd004-properties-interface AC8
-      - prd004-properties-interface AC9
-      - prd004-properties-interface AC12
+      - srd004-properties-interface AC8
+      - srd004-properties-interface AC9
+      - srd004-properties-interface AC12
 out_of_scope:
   - Core CRUD operations (Get, Set, Delete, Fetch) - see rel01.0-uc003
-  - Property deletion or renaming (not supported per prd004-properties-interface)
+  - Property deletion or renaming (not supported per srd004-properties-interface)
   - Trail operations - see rel03.0-uc001
   - Concurrent property definition and crumb creation
   - Property value validation beyond type checking
-  - Category deletion or renaming (not supported per prd004-properties-interface)
+  - Category deletion or renaming (not supported per srd004-properties-interface)
 test_suite: test-rel02.0

--- a/docs/specs/use-cases/rel02.0-uc002-regeneration-compatibility.yaml
+++ b/docs/specs/use-cases/rel02.0-uc002-regeneration-compatibility.yaml
@@ -10,37 +10,37 @@ flow:
   - F1: "Build and install generation N: Generation N is built, tested, and installed. The go install step places the cupboard binary in $GOBIN. This binary becomes the reference implementation for the current JSONL format."
   - F2: "Create JSONL data using generation N (requires installed binary from F1): Create crumbs using the generation N binary. This data represents the contract that generation N+1 must honor."
   - F3: "Run --regenerate (requires committed data from F2): The script tags the current repo state, deletes all Go source files, reinitializes the Go module, and commits. Internally runs git tag, find -delete, rm, go mod init, git add, git commit."
-  - F4: "Rebuild from documentation (requires clean slate from F3): The make-work/do-work loop rebuilds cupboard from documentation. The new code (generation N+1) is written by agents reading PRDs, architecture docs, and use cases. The agents produce a fresh implementation that must conform to the documented JSONL format (prd002-sqlite-backend R2)."
+  - F4: "Rebuild from documentation (requires clean slate from F3): The make-work/do-work loop rebuilds cupboard from documentation. The new code (generation N+1) is written by agents reading SRDs, architecture docs, and use cases. The agents produce a fresh implementation that must conform to the documented JSONL format (srd002-sqlite-backend R2)."
   - F5: "Build generation N+1 (requires rebuilt source from F4): Build and verify generation N+1 compiles successfully."
-  - F6: "Load generation N data with generation N+1 (requires N+1 binary from F5 and N data from F2): Point generation N+1 at the JSONL data created by generation N. The backend's startup sequence (prd002-sqlite-backend R4) loads JSONL into SQLite. If the format has drifted, this step fails."
+  - F6: "Load generation N data with generation N+1 (requires N+1 binary from F5 and N data from F2): Point generation N+1 at the JSONL data created by generation N. The backend's startup sequence (srd002-sqlite-backend R4) loads JSONL into SQLite. If the format has drifted, this step fails."
   - F7: "Verify read operations (requires loaded data from F6): Verify read operations against generation N data return correct values."
   - F8: "Verify write operations (requires successful reads from F7): Verify write operations update generation N data correctly. Generation N+1 must write JSONL in a format that both itself and generation N can read."
   - F9: "Verify generation N reads N+1 modifications (requires N+1 writes from F8 and installed N binary from F1): Verify the installed generation N binary can still read the data after generation N+1 modifies it. This confirms write compatibility in both directions."
   - F10: "Verify property operations across generations (requires property data from F2 and N+1 binary from F5): If generation N defined properties and set values, generation N+1 must load those properties and values correctly (requires rel02.0 property enforcement)."
 touchpoints:
   - T1: "mage openGeneration / closeGeneration: Orchestrates the regeneration cycle (tag, delete, reinit, rebuild)"
-  - T2: "SQLite backend startup: Loads JSONL files into SQLite; format must match across generations (prd002-sqlite-backend R4)"
-  - T3: "JSONL file format: The contract between generations; format stability is the invariant (prd002-sqlite-backend R2)"
-  - T4: "JSONL write path: Writes must produce JSONL that older and newer generations can parse (prd002-sqlite-backend R5)"
-  - T5: "Unknown field handling: Unknown fields in JSONL are ignored, enabling forward compatibility (prd002-sqlite-backend R7.2)"
-  - T6: "Cupboard interface: Attach/Detach, GetTable work identically across generations (prd001-cupboard-core R4, R5)"
-  - T7: "Property system: Property definitions and values persist across regeneration (prd004-properties-interface R4)"
+  - T2: "SQLite backend startup: Loads JSONL files into SQLite; format must match across generations (srd002-sqlite-backend R4)"
+  - T3: "JSONL file format: The contract between generations; format stability is the invariant (srd002-sqlite-backend R2)"
+  - T4: "JSONL write path: Writes must produce JSONL that older and newer generations can parse (srd002-sqlite-backend R5)"
+  - T5: "Unknown field handling: Unknown fields in JSONL are ignored, enabling forward compatibility (srd002-sqlite-backend R7.2)"
+  - T6: "Cupboard interface: Attach/Detach, GetTable work identically across generations (srd001-cupboard-core R4, R5)"
+  - T7: "Property system: Property definitions and values persist across regeneration (srd004-properties-interface R4)"
 success_criteria:
   - id: S1
     criterion: Forward compatibility holds; generation N+1, rebuilt entirely from documentation, loads JSONL data created by generation N without error and returns correct values for all read operations
     traces:
-      - prd002-sqlite-backend AC1
-      - prd002-sqlite-backend AC3
+      - srd002-sqlite-backend AC1
+      - srd002-sqlite-backend AC3
   - id: S2
     criterion: Backward compatibility holds; the installed generation N binary reads data modified by generation N+1 and returns updated values, confirming write format stability across generations
     traces:
-      - prd002-sqlite-backend AC1
-      - prd002-sqlite-backend AC4
+      - srd002-sqlite-backend AC1
+      - srd002-sqlite-backend AC4
   - id: S3
     criterion: Property data survives regeneration; properties and values created by generation N are loaded correctly by generation N+1, confirming cross-component format stability between the property system and JSONL persistence
     traces:
-      - prd004-properties-interface AC5
-      - prd002-sqlite-backend AC3
+      - srd004-properties-interface AC5
+      - srd002-sqlite-backend AC3
 out_of_scope:
   - Schema migrations or versioned JSONL formats (we rely on format stability and unknown-field tolerance)
   - Testing more than two generations in sequence (N and N+1 only)

--- a/docs/specs/use-cases/rel02.1-uc001-issue-tracking-cli.yaml
+++ b/docs/specs/use-cases/rel02.1-uc001-issue-tracking-cli.yaml
@@ -25,30 +25,30 @@ flow:
   - F13: "Verify final state (requires close from F12): run cupboard show <id> to confirm state is closed"
   - F14: "Confirm ready excludes closed (requires closed task from F12): run cupboard ready --json --type task and verify closed task is absent"
 touchpoints:
-  - T1: "Cupboard interface: GetTable('crumbs') (prd001-cupboard-core R2)"
-  - T2: "Table interface: Get, Set, Fetch (prd001-cupboard-core R3)"
-  - T3: "cupboard CLI create command: creation via Table.Set (prd003-crumbs-interface R3)"
-  - T4: "cupboard CLI ready command: Fetch with filter (prd003-crumbs-interface R9, R10)"
-  - T5: "cupboard CLI update command: SetState (prd003-crumbs-interface R4)"
-  - T6: "cupboard CLI close command: Pebble (prd003-crumbs-interface R4.3)"
-  - T7: "cupboard CLI show command: Table.Get (prd001-cupboard-core R3.2)"
-  - T8: "cupboard CLI list command: Table.Fetch (prd003-crumbs-interface R10)"
-  - T9: "cupboard CLI comments add command: metadata (prd002-sqlite-backend R2.8)"
-  - T10: "Crumb entity: state transitions, properties (prd003-crumbs-interface R2, R4, R5)"
-  - T11: "Properties: type, priority, labels (prd004-properties-interface R9)"
-  - T12: "SQLite backend: JSONL persistence (prd002-sqlite-backend R5)"
+  - T1: "Cupboard interface: GetTable('crumbs') (srd001-cupboard-core R2)"
+  - T2: "Table interface: Get, Set, Fetch (srd001-cupboard-core R3)"
+  - T3: "cupboard CLI create command: creation via Table.Set (srd003-crumbs-interface R3)"
+  - T4: "cupboard CLI ready command: Fetch with filter (srd003-crumbs-interface R9, R10)"
+  - T5: "cupboard CLI update command: SetState (srd003-crumbs-interface R4)"
+  - T6: "cupboard CLI close command: Pebble (srd003-crumbs-interface R4.3)"
+  - T7: "cupboard CLI show command: Table.Get (srd001-cupboard-core R3.2)"
+  - T8: "cupboard CLI list command: Table.Fetch (srd003-crumbs-interface R10)"
+  - T9: "cupboard CLI comments add command: metadata (srd002-sqlite-backend R2.8)"
+  - T10: "Crumb entity: state transitions, properties (srd003-crumbs-interface R2, R4, R5)"
+  - T11: "Properties: type, priority, labels (srd004-properties-interface R9)"
+  - T12: "SQLite backend: JSONL persistence (srd002-sqlite-backend R5)"
 success_criteria:
   - id: S1
     criterion: Full issue lifecycle completes through CLI commands; create produces a crumb with properties, update transitions state, close marks as closed, and ready correctly excludes non-open tasks — confirming the seven issue-tracking commands compose into a working workflow
     traces:
-      - prd009-cupboard-cli AC3
-      - prd003-crumbs-interface AC3
-      - prd003-crumbs-interface AC4
+      - srd009-cupboard-cli AC3
+      - srd003-crumbs-interface AC3
+      - srd003-crumbs-interface AC4
   - id: S2
     criterion: Comment-to-CLI pipeline works end-to-end; comments add appends metadata visible in show output, confirming the metadata system integrates with the issue-tracking CLI
     traces:
-      - prd005-metadata-interface AC5
-      - prd005-metadata-interface AC7
+      - srd005-metadata-interface AC5
+      - srd005-metadata-interface AC7
 out_of_scope:
   - Script integration (do-work.sh, make-work.sh) covered by rel02.1-uc003-self-hosting Phase 2
   - Interactive agent workflow rules covered by rel02.1-uc003-self-hosting Phase 3

--- a/docs/specs/use-cases/rel02.1-uc002-table-benchmarks.yaml
+++ b/docs/specs/use-cases/rel02.1-uc002-table-benchmarks.yaml
@@ -20,29 +20,29 @@ flow:
   - F8: "Run benchmarks and capture baseline (requires all benchmarks from F2-F7): go test -bench=. -benchmem ./internal/sqlite/..."
   - F9: "Compare against baseline on code changes (requires baseline from F8): use benchstat for statistical comparison"
 touchpoints:
-  - T1: "Table interface: Get, Set, Delete, Fetch (prd001-cupboard-core R3)"
-  - T2: "SQLite backend: entity hydration from rows (prd002-sqlite-backend R14)"
-  - T3: "SQLite backend: entity persistence to rows (prd002-sqlite-backend R15)"
-  - T4: "SQLite backend: JSONL atomic write (prd002-sqlite-backend R5.2)"
-  - T5: "SQLite backend: immediate sync strategy (prd002-sqlite-backend R16.2)"
-  - T6: "Crumb entity: SetProperty, GetProperty (prd003-crumbs-interface R5)"
-  - T7: "Crumb table: filter map queries (prd003-crumbs-interface R9)"
-  - T8: "SQLite backend: idx_crumbs_state index (prd002-sqlite-backend R3.3)"
+  - T1: "Table interface: Get, Set, Delete, Fetch (srd001-cupboard-core R3)"
+  - T2: "SQLite backend: entity hydration from rows (srd002-sqlite-backend R14)"
+  - T3: "SQLite backend: entity persistence to rows (srd002-sqlite-backend R15)"
+  - T4: "SQLite backend: JSONL atomic write (srd002-sqlite-backend R5.2)"
+  - T5: "SQLite backend: immediate sync strategy (srd002-sqlite-backend R16.2)"
+  - T6: "Crumb entity: SetProperty, GetProperty (srd003-crumbs-interface R5)"
+  - T7: "Crumb table: filter map queries (srd003-crumbs-interface R9)"
+  - T8: "SQLite backend: idx_crumbs_state index (srd002-sqlite-backend R3.3)"
 success_criteria:
   - id: S1
     criterion: Full benchmark suite completes without error and captures baseline; all Get, Set, Delete, Fetch, and property benchmarks at multiple scales produce ns/op, B/op, and allocs/op output committed as baseline.txt for regression tracking
     traces:
-      - prd001-cupboard-core AC4
-      - prd002-sqlite-backend AC14
+      - srd001-cupboard-core AC4
+      - srd002-sqlite-backend AC14
   - id: S2
     criterion: Benchmark results are consistent and cover multi-scale data sizes; each benchmark reports variance under 10% across runs, and the suite spans 10 to 10000 entity scales to catch scaling regressions
     traces:
-      - prd002-sqlite-backend AC14
-      - prd002-sqlite-backend AC15
+      - srd002-sqlite-backend AC14
+      - srd002-sqlite-backend AC15
 out_of_scope:
-  - Concurrent access benchmarks (prd002-sqlite-backend R8 describes single-writer model)
+  - Concurrent access benchmarks (srd002-sqlite-backend R8 describes single-writer model)
   - Network latency (SQLite backend is local; no network overhead)
   - CLI command overhead (benchmarks measure Table interface, not CLI parsing)
-  - Non-immediate sync strategies (prd002-sqlite-backend R16.3, R16.4 are deferred performance options)
+  - Non-immediate sync strategies (srd002-sqlite-backend R16.3, R16.4 are deferred performance options)
   - Trail and stash operations (those entity types are in later releases)
 test_suite: test-rel02.1

--- a/docs/specs/use-cases/rel02.1-uc003-self-hosting.yaml
+++ b/docs/specs/use-cases/rel02.1-uc003-self-hosting.yaml
@@ -15,31 +15,31 @@ flow:
   - F1: "Implement issue-tracking CLI commands: ready, create, update, close, show, list, comments"
   - F2: "Support JSON output (parallel to F1): the --json flag outputs JSON for script consumption; without it, output is human-readable"
   - F3: "Handle crumb creation options (requires create command from F1): cupboard create accepts --type, --title, --description, --parent, --labels"
-  - F4: "Follow state transitions (requires update/close from F1): draft, pending, ready, taken, pebble, dust (prd003-crumbs-interface R2)"
+  - F4: "Follow state transitions (requires update/close from F1): draft, pending, ready, taken, pebble, dust (srd003-crumbs-interface R2)"
   - F5: "Integrate do-work.sh script (requires commands from F1-F4): use cupboard commands to pick a task, claim it, and close it after completion"
   - F6: "Integrate make-work.sh script (requires commands from F1-F3): use cupboard commands to list existing issues and create new ones"
-  - F7: "Handle JSONL sync (exercised by F5-F6): no explicit sync command needed; SQLite backend syncs on every write using immediate sync strategy (prd002-sqlite-backend R5, R16)"
+  - F7: "Handle JSONL sync (exercised by F5-F6): no explicit sync command needed; SQLite backend syncs on every write using immediate sync strategy (srd002-sqlite-backend R5, R16)"
   - F8: "Reference cupboard commands in agent workflow rule (requires commands from F1): .claude/rules/ references cupboard commands for interactive use"
   - F9: "Commit JSONL files to git (after F5/F6 complete): per eng01-git-integration, JSONL files are committed as part of session completion"
 touchpoints:
-  - T1: "cupboard CLI (cmd/cupboard): issue-tracking commands ready, create, close, update, show, list, comments (prd003-crumbs-interface R3, R4, R10)"
-  - T2: "Cupboard library (pkg/types): Cupboard interface with GetTable, Table interface for CRUD, Crumb/Property entities (prd001-cupboard-core R2, R3; prd003-crumbs-interface R1)"
-  - T3: "SQLite backend (internal/sqlite): storage, JSONL persistence, query engine, entity hydration (prd002-sqlite-backend R1-R5, R12-R15)"
-  - T4: "do-work.sh: task picking (Fetch), worktree management, agent invocation (prd003-crumbs-interface R9, R10)"
-  - T5: "make-work.sh: work creation (Set), issue import (prd003-crumbs-interface R3; prd001-cupboard-core R3.3)"
+  - T1: "cupboard CLI (cmd/cupboard): issue-tracking commands ready, create, close, update, show, list, comments (srd003-crumbs-interface R3, R4, R10)"
+  - T2: "Cupboard library (pkg/types): Cupboard interface with GetTable, Table interface for CRUD, Crumb/Property entities (srd001-cupboard-core R2, R3; srd003-crumbs-interface R1)"
+  - T3: "SQLite backend (internal/sqlite): storage, JSONL persistence, query engine, entity hydration (srd002-sqlite-backend R1-R5, R12-R15)"
+  - T4: "do-work.sh: task picking (Fetch), worktree management, agent invocation (srd003-crumbs-interface R9, R10)"
+  - T5: "make-work.sh: work creation (Set), issue import (srd003-crumbs-interface R3; srd001-cupboard-core R3.3)"
   - T6: ".claude/rules/: agent workflow instructions (eng01-git-integration)"
 success_criteria:
   - id: S1
     criterion: do-work.sh completes a full cycle (pick task via ready, claim via update, close after completion) using issue-tracking CLI commands, confirming that cupboard serves as a working issue tracker for agent workflows with properties and state transitions
     traces:
-      - prd009-cupboard-cli AC3
-      - prd003-crumbs-interface AC3
-      - prd003-crumbs-interface AC4
+      - srd009-cupboard-cli AC3
+      - srd003-crumbs-interface AC3
+      - srd003-crumbs-interface AC4
   - id: S2
     criterion: make-work.sh creates issues via cupboard create with type, title, and description, and the resulting JSONL files can be committed to git, confirming the create-and-commit workflow for agent task creation with properties
     traces:
-      - prd009-cupboard-cli AC3
-      - prd002-sqlite-backend AC1
+      - srd009-cupboard-cli AC3
+      - srd002-sqlite-backend AC1
 out_of_scope:
   - Multi-agent coordination (single agent self-hosting)
   - Remote backends (SQLite only)

--- a/docs/specs/use-cases/rel02.1-uc004-metadata-lifecycle.yaml
+++ b/docs/specs/use-cases/rel02.1-uc004-metadata-lifecycle.yaml
@@ -31,29 +31,29 @@ flow:
   - F13: "Verify cascade delete (requires deletion from F12): call table.Fetch with crumb_id filter for the deleted crumb; the result is empty, confirming all metadata was removed"
   - F14: "Detach: call cupboard.Detach() to release resources"
 touchpoints:
-  - T1: "Cupboard interface: Attach, GetTable, Detach (prd001-cupboard-core R2)"
-  - T2: "Table interface: Get, Set, Delete, Fetch (prd001-cupboard-core R3)"
-  - T3: "Metadata struct: MetadataID, CrumbID, TableName, Content, PropertyID, CreatedAt (prd005-metadata-interface R1)"
-  - T4: "Built-in schemas: comments (text), attachments (json) (prd005-metadata-interface R3)"
-  - T5: "Metadata creation via Table.Set: UUID v7 generation, timestamp (prd005-metadata-interface R4)"
-  - T6: "Metadata retrieval via Table.Get: type assertion to *Metadata (prd005-metadata-interface R5)"
-  - T7: "Filter map: schema, crumb_id filters (prd005-metadata-interface R7)"
-  - T8: "Cascade delete: metadata removed when crumb deleted (prd005-metadata-interface R6.5)"
-  - T9: "Error types: ErrNotFound, ErrInvalidID (prd005-metadata-interface R10)"
+  - T1: "Cupboard interface: Attach, GetTable, Detach (srd001-cupboard-core R2)"
+  - T2: "Table interface: Get, Set, Delete, Fetch (srd001-cupboard-core R3)"
+  - T3: "Metadata struct: MetadataID, CrumbID, TableName, Content, PropertyID, CreatedAt (srd005-metadata-interface R1)"
+  - T4: "Built-in schemas: comments (text), attachments (json) (srd005-metadata-interface R3)"
+  - T5: "Metadata creation via Table.Set: UUID v7 generation, timestamp (srd005-metadata-interface R4)"
+  - T6: "Metadata retrieval via Table.Get: type assertion to *Metadata (srd005-metadata-interface R5)"
+  - T7: "Filter map: schema, crumb_id filters (srd005-metadata-interface R7)"
+  - T8: "Cascade delete: metadata removed when crumb deleted (srd005-metadata-interface R6.5)"
+  - T9: "Error types: ErrNotFound, ErrInvalidID (srd005-metadata-interface R10)"
 success_criteria:
   - id: S1
     criterion: Additive metadata accumulation and filter composition work end-to-end; multiple comments and attachments accumulate on a crumb, schema and crumb_id filters return correct subsets, and combined filters AND correctly — confirming the append-only pattern and query system integrate across the metadata table
     traces:
-      - prd005-metadata-interface AC5
-      - prd005-metadata-interface AC7
-      - prd005-metadata-interface AC9
+      - srd005-metadata-interface AC5
+      - srd005-metadata-interface AC7
+      - srd005-metadata-interface AC9
   - id: S2
     criterion: Cascade delete maintains referential integrity; deleting a crumb removes all its metadata entries, and subsequent Fetch with crumb_id filter returns empty — confirming cross-table lifecycle coupling between crumbs and metadata
     traces:
-      - prd005-metadata-interface AC7
-      - prd003-crumbs-interface AC10
+      - srd005-metadata-interface AC7
+      - srd003-crumbs-interface AC10
 out_of_scope:
-  - Schema registration for custom metadata types (see prd005-metadata-interface R9)
+  - Schema registration for custom metadata types (see srd005-metadata-interface R9)
   - PropertyID linking for property-specific metadata
   - Content validation (content_contains filter, JSON validation)
   - Limit and offset pagination

--- a/docs/specs/use-cases/rel03.0-uc001-trail-exploration.yaml
+++ b/docs/specs/use-cases/rel03.0-uc001-trail-exploration.yaml
@@ -25,32 +25,32 @@ flow:
   - F15: "Filter crumbs by trail (requires completion from F13): query links for completed trail returns empty (links removed on complete)"
   - F16: "Detach the cupboard: call cupboard.Detach()"
 touchpoints:
-  - T1: "Cupboard interface: Attach, Detach, GetTable (prd001-cupboard-core R2)"
-  - T2: "Table (crumbs): Get, Set, Delete, Fetch (prd001-cupboard-core R3)"
-  - T3: "Table (trails): Get, Set (prd001-cupboard-core R3)"
-  - T4: "Table (links): Get, Set, Delete, Fetch with belongs_to/branches_from filters (prd007-links-interface R3, R4)"
-  - T5: "Trail entity: Complete, Abandon, SetState methods (prd006-trails-interface R2, R5, R6)"
-  - T6: "Trail creation via Table.Set (prd006-trails-interface R3); defaults to draft state"
-  - T7: "Crumb-trail membership via belongs_to links (prd006-trails-interface R7)"
-  - T8: "Trail completion makes crumbs permanent by removing links (prd006-trails-interface R5)"
-  - T9: "Trail abandonment deletes associated crumbs atomically (prd006-trails-interface R6)"
-  - T10: "Link-based querying for trail membership (prd002-sqlite-backend R12, R13)"
+  - T1: "Cupboard interface: Attach, Detach, GetTable (srd001-cupboard-core R2)"
+  - T2: "Table (crumbs): Get, Set, Delete, Fetch (srd001-cupboard-core R3)"
+  - T3: "Table (trails): Get, Set (srd001-cupboard-core R3)"
+  - T4: "Table (links): Get, Set, Delete, Fetch with belongs_to/branches_from filters (srd007-links-interface R3, R4)"
+  - T5: "Trail entity: Complete, Abandon, SetState methods (srd006-trails-interface R2, R5, R6)"
+  - T6: "Trail creation via Table.Set (srd006-trails-interface R3); defaults to draft state"
+  - T7: "Crumb-trail membership via belongs_to links (srd006-trails-interface R7)"
+  - T8: "Trail completion makes crumbs permanent by removing links (srd006-trails-interface R5)"
+  - T9: "Trail abandonment deletes associated crumbs atomically (srd006-trails-interface R6)"
+  - T10: "Link-based querying for trail membership (srd002-sqlite-backend R12, R13)"
 success_criteria:
   - id: S1
     criterion: Trail lifecycle completes with both outcomes; completion makes crumbs permanent by removing belongs_to links while crumbs persist, and abandonment deletes associated crumbs atomically — confirming the dual lifecycle paths work through the Table interface
     traces:
-      - prd006-trails-interface AC5
-      - prd006-trails-interface AC7
+      - srd006-trails-interface AC5
+      - srd006-trails-interface AC7
   - id: S2
     criterion: Crumbs removed from a trail before abandonment survive the cascade; only currently-linked crumbs are deleted, while previously disassociated crumbs remain — confirming selective cleanup based on link state
     traces:
-      - prd006-trails-interface AC8
-      - prd007-links-interface AC4
+      - srd006-trails-interface AC8
+      - srd007-links-interface AC4
   - id: S3
     criterion: Link-based trail queries return correct membership; belongs_to filter on links table enumerates trail crumbs during active state, and completed trail query returns empty — confirming link lifecycle coupling with trail state
     traces:
-      - prd007-links-interface AC5
-      - prd006-trails-interface AC6
+      - srd007-links-interface AC5
+      - srd006-trails-interface AC6
 out_of_scope:
   - Nested trails (trails containing trails)
   - Trail merging or splitting

--- a/docs/specs/use-cases/rel03.0-uc002-link-management.yaml
+++ b/docs/specs/use-cases/rel03.0-uc002-link-management.yaml
@@ -29,33 +29,33 @@ flow:
   - F18: "Verify uniqueness (requires existing link from F3): attempt duplicate link creation with same link_type+from_id+to_id"
   - F19: "Detach the cupboard: call cupboard.Detach()"
 touchpoints:
-  - T1: "Cupboard interface: Attach, Detach, GetTable (prd001-cupboard-core R2)"
-  - T2: "Table (links): Get, Set, Delete, Fetch (prd007-links-interface R3, R4)"
-  - T3: "Table (crumbs): Set for creating prerequisite crumbs (prd001-cupboard-core R3)"
-  - T4: "Table (trails): Set for creating prerequisite trails (prd001-cupboard-core R3)"
-  - T5: "Table (stashes): Set for creating prerequisite stashes (prd001-cupboard-core R3)"
-  - T6: "Link entity: LinkID, LinkType, FromID, ToID, CreatedAt fields (prd002-sqlite-backend R14.6)"
-  - T7: "belongs_to link type: crumb→trail membership (prd006-trails-interface R7)"
-  - T8: "child_of link type: crumb→crumb hierarchy (prd007-links-interface R2.1)"
-  - T9: "branches_from link type: trail→crumb branch point (prd006-trails-interface R9)"
-  - T10: "scoped_to link type: stash→trail scope (prd008-stash-interface R13)"
-  - T11: "Link table indexes: idx_links_type_from, idx_links_type_to (prd002-sqlite-backend R3.3)"
+  - T1: "Cupboard interface: Attach, Detach, GetTable (srd001-cupboard-core R2)"
+  - T2: "Table (links): Get, Set, Delete, Fetch (srd007-links-interface R3, R4)"
+  - T3: "Table (crumbs): Set for creating prerequisite crumbs (srd001-cupboard-core R3)"
+  - T4: "Table (trails): Set for creating prerequisite trails (srd001-cupboard-core R3)"
+  - T5: "Table (stashes): Set for creating prerequisite stashes (srd001-cupboard-core R3)"
+  - T6: "Link entity: LinkID, LinkType, FromID, ToID, CreatedAt fields (srd002-sqlite-backend R14.6)"
+  - T7: "belongs_to link type: crumb→trail membership (srd006-trails-interface R7)"
+  - T8: "child_of link type: crumb→crumb hierarchy (srd007-links-interface R2.1)"
+  - T9: "branches_from link type: trail→crumb branch point (srd006-trails-interface R9)"
+  - T10: "scoped_to link type: stash→trail scope (srd008-stash-interface R13)"
+  - T11: "Link table indexes: idx_links_type_from, idx_links_type_to (srd002-sqlite-backend R3.3)"
 success_criteria:
   - id: S1
     criterion: All four link types (belongs_to, child_of, branches_from, scoped_to) create and retrieve correctly through the uniform Table interface, confirming that the links table handles all cross-entity relationship semantics
     traces:
-      - prd007-links-interface AC2
-      - prd007-links-interface AC4
+      - srd007-links-interface AC2
+      - srd007-links-interface AC4
   - id: S2
     criterion: Filter-based queries return correct subsets; link_type, from_id, and to_id filters narrow results independently, and combined filters AND correctly — confirming the filter map works across all link types
     traces:
-      - prd007-links-interface AC5
-      - prd007-links-interface AC6
+      - srd007-links-interface AC5
+      - srd007-links-interface AC6
   - id: S3
     criterion: Delete removes link permanently with subsequent Get returning ErrNotFound, and delete of nonexistent link also returns ErrNotFound — confirming link lifecycle consistency
     traces:
-      - prd007-links-interface AC4
-      - prd007-links-interface AC9
+      - srd007-links-interface AC4
+      - srd007-links-interface AC9
 out_of_scope:
   - Trail cascade behavior on Complete/Abandon (see rel03.0-uc001)
   - Graph traversal or cycle detection (R10 ValidateDAG)

--- a/docs/specs/use-cases/rel03.0-uc003-stash-operations.yaml
+++ b/docs/specs/use-cases/rel03.0-uc003-stash-operations.yaml
@@ -33,35 +33,35 @@ flow:
   - F22: "Verify history entries (requires history from F21): confirm entries have correct version, operation, and value snapshots"
   - F23: "Detach the cupboard: call cupboard.Detach()"
 touchpoints:
-  - T1: "Cupboard interface: Attach, Detach, GetTable (prd001-cupboard-core R2)"
-  - T2: "Table (stashes): Get, Set, Delete, Fetch (prd001-cupboard-core R3)"
-  - T3: "Stash entity: StashID, Name, StashType, Value, Version, CreatedAt fields (prd008-stash-interface R1)"
-  - T4: "Stash types: resource, artifact, context, counter, lock (prd008-stash-interface R2)"
-  - T5: "SetValue/GetValue methods for value access (prd008-stash-interface R4)"
-  - T6: "Increment method for counter operations (prd008-stash-interface R5)"
-  - T7: "Acquire/Release methods for lock operations (prd008-stash-interface R6)"
-  - T8: "Version tracking across mutations (prd008-stash-interface R1.6)"
-  - T9: "Filter map for stash queries: stash_type, name (prd008-stash-interface R9)"
-  - T10: "Stash history tracking: FetchStashHistory method (prd008-stash-interface R7)"
+  - T1: "Cupboard interface: Attach, Detach, GetTable (srd001-cupboard-core R2)"
+  - T2: "Table (stashes): Get, Set, Delete, Fetch (srd001-cupboard-core R3)"
+  - T3: "Stash entity: StashID, Name, StashType, Value, Version, CreatedAt fields (srd008-stash-interface R1)"
+  - T4: "Stash types: resource, artifact, context, counter, lock (srd008-stash-interface R2)"
+  - T5: "SetValue/GetValue methods for value access (srd008-stash-interface R4)"
+  - T6: "Increment method for counter operations (srd008-stash-interface R5)"
+  - T7: "Acquire/Release methods for lock operations (srd008-stash-interface R6)"
+  - T8: "Version tracking across mutations (srd008-stash-interface R1.6)"
+  - T9: "Filter map for stash queries: stash_type, name (srd008-stash-interface R9)"
+  - T10: "Stash history tracking: FetchStashHistory method (srd008-stash-interface R7)"
 success_criteria:
   - id: S1
     criterion: All five stash types create and operate correctly through the Table interface; resource/artifact/context use SetValue/GetValue, counter uses Increment with positive and negative deltas, lock uses Acquire/Release with reentrant and contention semantics — confirming type-specific operations compose with the uniform storage layer
     traces:
-      - prd008-stash-interface AC2
-      - prd008-stash-interface AC3
-      - prd008-stash-interface AC4
-      - prd008-stash-interface AC5
+      - srd008-stash-interface AC2
+      - srd008-stash-interface AC3
+      - srd008-stash-interface AC4
+      - srd008-stash-interface AC5
   - id: S2
     criterion: Version tracking is consistent across all mutation types; Version starts at 1 and increments on every operation (create, set, increment, acquire, release), with FetchStashHistory returning entries for each mutation ordered by version ascending
     traces:
-      - prd008-stash-interface AC1
-      - prd008-stash-interface AC6
-      - prd008-stash-interface AC7
+      - srd008-stash-interface AC1
+      - srd008-stash-interface AC6
+      - srd008-stash-interface AC7
   - id: S3
     criterion: Fetch with stash_type and name filters returns correct subsets, and delete removes stash with subsequent Get returning ErrNotFound — confirming query and lifecycle operations through the Table interface
     traces:
-      - prd008-stash-interface AC10
-      - prd008-stash-interface AC12
+      - srd008-stash-interface AC10
+      - srd008-stash-interface AC12
 out_of_scope:
   - Stash scoping via scoped_to links (see rel03.0-uc002)
   - Blocking lock acquisition with timeout

--- a/docs/specs/use-cases/rel03.0-uc004-trail-crumb-lifecycle.yaml
+++ b/docs/specs/use-cases/rel03.0-uc004-trail-crumb-lifecycle.yaml
@@ -31,31 +31,31 @@ flow:
   - F13: "Verify cascade deletion (requires abandonment from F12): crumbs return ErrNotFound, all related links deleted, properties cleaned up"
   - F14: "Detach the cupboard: call cupboard.Detach()"
 touchpoints:
-  - T1: "Cupboard interface: Attach, Detach, GetTable (prd001-cupboard-core R2)"
-  - T2: "Table interface: Get, Set, Delete, Fetch (prd001-cupboard-core R3)"
-  - T3: "Trail entity: SetState method for state transitions (prd006-trails-interface R2)"
-  - T4: "Trail entity: Complete method marks crumbs permanent (prd006-trails-interface R5)"
-  - T5: "Trail entity: Abandon method triggers cascade deletion (prd006-trails-interface R6)"
-  - T6: "belongs_to links: crumb → trail membership (prd007-links-interface R2.1)"
-  - T7: "Cardinality constraint: crumb belongs to at most one trail (prd007-links-interface R6.1)"
-  - T8: "Backend cascade on complete: removes belongs_to links (prd006-trails-interface R5.6)"
-  - T9: "Backend cascade on abandon: deletes crumbs, properties, links atomically (prd006-trails-interface R6.6, R6.7)"
+  - T1: "Cupboard interface: Attach, Detach, GetTable (srd001-cupboard-core R2)"
+  - T2: "Table interface: Get, Set, Delete, Fetch (srd001-cupboard-core R3)"
+  - T3: "Trail entity: SetState method for state transitions (srd006-trails-interface R2)"
+  - T4: "Trail entity: Complete method marks crumbs permanent (srd006-trails-interface R5)"
+  - T5: "Trail entity: Abandon method triggers cascade deletion (srd006-trails-interface R6)"
+  - T6: "belongs_to links: crumb → trail membership (srd007-links-interface R2.1)"
+  - T7: "Cardinality constraint: crumb belongs to at most one trail (srd007-links-interface R6.1)"
+  - T8: "Backend cascade on complete: removes belongs_to links (srd006-trails-interface R5.6)"
+  - T9: "Backend cascade on abandon: deletes crumbs, properties, links atomically (srd006-trails-interface R6.6, R6.7)"
 success_criteria:
   - id: S1
     criterion: Trail completion makes crumbs permanent; Complete removes all belongs_to links but crumbs persist without trail association, indistinguishable from never-trailed crumbs — confirming the link-removal cascade on the completion path
     traces:
-      - prd006-trails-interface AC5
-      - prd006-trails-interface AC6
+      - srd006-trails-interface AC5
+      - srd006-trails-interface AC6
   - id: S2
     criterion: Trail abandonment deletes crumbs atomically; Abandon removes crumbs, their properties, metadata, and all links involving the crumb — confirming cascade deletion across multiple tables
     traces:
-      - prd006-trails-interface AC7
-      - prd006-trails-interface AC8
+      - srd006-trails-interface AC7
+      - srd006-trails-interface AC8
   - id: S3
     criterion: Crumb-trail cardinality is enforced; a crumb belongs to at most one trail, and crumbs can move between trails by deleting and recreating belongs_to links — confirming membership constraints through the links table
     traces:
-      - prd007-links-interface AC8
-      - prd006-trails-interface AC9
+      - srd007-links-interface AC8
+      - srd006-trails-interface AC9
 out_of_scope:
   - Trail branching via branches_from links (see rel03.0-uc001-trail-exploration)
   - Nested trails or trail hierarchies

--- a/docs/specs/use-cases/rel03.1-uc001-self-hosting-with-epics.yaml
+++ b/docs/specs/use-cases/rel03.1-uc001-self-hosting-with-epics.yaml
@@ -36,12 +36,12 @@ flow:
   - F15: "Commit JSONL files to git (after F13/F14 complete): per eng01-git-integration, all JSONL files are committed including trails and links"
 touchpoints:
   - T1: "cupboard CLI (cmd/cupboard): generic table commands get, set, list, delete for trails, crumbs, and links"
-  - T2: "Cupboard library (pkg/types): Cupboard interface with GetTable, Table interface for CRUD (prd001-cupboard-core R2, R3)"
-  - T3: "Trail entity (pkg/types): State field, lifecycle transitions draft→active→completed/abandoned (prd006-trails-interface R2)"
-  - T4: "Trail completion semantics: removes belongs_to links, crumbs become permanent (prd006-trails-interface R5)"
-  - T5: "Trail abandonment semantics: deletes associated crumbs atomically (prd006-trails-interface R6)"
-  - T6: "Links table: belongs_to links associate crumbs with trails (prd007-links-interface R2.1)"
-  - T7: "SQLite backend (internal/sqlite): storage, JSONL persistence, cascade operations (prd002-sqlite-backend R1-R5)"
+  - T2: "Cupboard library (pkg/types): Cupboard interface with GetTable, Table interface for CRUD (srd001-cupboard-core R2, R3)"
+  - T3: "Trail entity (pkg/types): State field, lifecycle transitions draft→active→completed/abandoned (srd006-trails-interface R2)"
+  - T4: "Trail completion semantics: removes belongs_to links, crumbs become permanent (srd006-trails-interface R5)"
+  - T5: "Trail abandonment semantics: deletes associated crumbs atomically (srd006-trails-interface R6)"
+  - T6: "Links table: belongs_to links associate crumbs with trails (srd007-links-interface R2.1)"
+  - T7: "SQLite backend (internal/sqlite): storage, JSONL persistence, cascade operations (srd002-sqlite-backend R1-R5)"
   - T8: "do-work.sh: optionally creates trail for grouped work, completes trail on merge"
   - T9: "make-work.sh: maps epics to trails, child tasks to belongs_to-linked crumbs"
   - T10: ".claude/rules/: agent workflow instructions referencing trail-based epic management"
@@ -49,14 +49,14 @@ success_criteria:
   - id: S1
     criterion: do-work.sh completes a full cycle with trail-based epic grouping; create trail, add crumbs via belongs_to links, work tasks through state transitions, complete trail to finalize — confirming trails serve as epic containers for agent workflows
     traces:
-      - prd006-trails-interface AC3
-      - prd006-trails-interface AC5
-      - prd003-crumbs-interface AC3
+      - srd006-trails-interface AC3
+      - srd006-trails-interface AC5
+      - srd003-crumbs-interface AC3
   - id: S2
     criterion: make-work.sh creates epics as trails, groups child tasks via belongs_to links, and the resulting JSONL files (trails.jsonl, links.jsonl, crumbs.jsonl) can be committed to git — confirming the create-and-commit workflow extends to trail-based organization
     traces:
-      - prd006-trails-interface AC3
-      - prd002-sqlite-backend AC1
+      - srd006-trails-interface AC3
+      - srd002-sqlite-backend AC1
 out_of_scope:
   - Nested trails (trails containing trails) - not supported per rel03.0-uc001
   - Trail merging or splitting

--- a/docs/specs/use-cases/rel04.0-uc001-branch-independent-data.yaml
+++ b/docs/specs/use-cases/rel04.0-uc001-branch-independent-data.yaml
@@ -6,7 +6,7 @@ summary: |
   visible and consistent regardless of which branch the developer has checked out. Switching
   or abandoning a code branch does not affect issue state.
 
-  This validates prd012-branch-independent-data: the data directory is a fixed path, JSONL
+  This validates srd012-branch-independent-data: the data directory is a fixed path, JSONL
   lives on main, and issue lifecycle is decoupled from git branch lifecycle.
 actor: Developer or coding agent working on a feature branch in a git repository with cupboard configured
 trigger: Developer begins work on a code feature branch while issue tracking is active on main
@@ -22,24 +22,24 @@ flow:
   - F9: "Developer abandons the feature branch without merging (requires branch from F4)"
   - F10: "Developer verifies all issues are intact on main after branch abandonment (requires abandonment from F9)"
 touchpoints:
-  - T1: Data directory is a fixed path resolved from configuration, not from branch name (prd012-branch-independent-data R1.1, R1.2)
-  - T2: JSONL files committed to main independent of feature branch (prd012-branch-independent-data R2.1, R2.2)
-  - T3: Issue state visible from any branch via the data directory (prd012-branch-independent-data R2.3)
-  - T4: Abandoning a code branch does not affect issue state (prd012-branch-independent-data R3.3)
-  - T5: SQLite rebuilt from JSONL on Attach; cupboard.db gitignored (prd002-sqlite-backend R4, R1.1; prd012-branch-independent-data R1.4)
-  - T6: Commit message references crumb IDs for traceability (prd012-branch-independent-data R4.1)
-  - T7: Cupboard CLI resolves data directory from configuration (prd010-configuration-directories R1, R2)
+  - T1: Data directory is a fixed path resolved from configuration, not from branch name (srd012-branch-independent-data R1.1, R1.2)
+  - T2: JSONL files committed to main independent of feature branch (srd012-branch-independent-data R2.1, R2.2)
+  - T3: Issue state visible from any branch via the data directory (srd012-branch-independent-data R2.3)
+  - T4: Abandoning a code branch does not affect issue state (srd012-branch-independent-data R3.3)
+  - T5: SQLite rebuilt from JSONL on Attach; cupboard.db gitignored (srd002-sqlite-backend R4, R1.1; srd012-branch-independent-data R1.4)
+  - T6: Commit message references crumb IDs for traceability (srd012-branch-independent-data R4.1)
+  - T7: Cupboard CLI resolves data directory from configuration (srd010-configuration-directories R1, R2)
 success_criteria:
   - id: S1
     criterion: Issue state persists across branch operations; crumbs created and updated from any branch are visible from main after JSONL commit, and switching branches does not affect issue data — confirming the data directory is branch-independent
     traces:
-      - prd012-branch-independent-data AC1
-      - prd012-branch-independent-data AC2
+      - srd012-branch-independent-data AC1
+      - srd012-branch-independent-data AC2
   - id: S2
     criterion: Abandoning a code branch leaves all issue state intact on main; cupboard list after branch deletion returns identical count and state — confirming complete decoupling of issue lifecycle from git branch lifecycle
     traces:
-      - prd012-branch-independent-data AC4
-      - prd012-branch-independent-data AC5
+      - srd012-branch-independent-data AC4
+      - srd012-branch-independent-data AC5
 out_of_scope:
   - Conflict resolution if JSONL is modified on two branches simultaneously
   - CI/CD automation of JSONL commits to main

--- a/docs/specs/use-cases/rel99.0-uc001-blazes-templates.yaml
+++ b/docs/specs/use-cases/rel99.0-uc001-blazes-templates.yaml
@@ -25,33 +25,33 @@ flow:
   - F6: "Extract parameters (requires selected template from F5): read the parameters section with name, description, type, and optional default; determine which can be inferred from context and which require user input"
   - F7: "Present selection (requires template and parameters from F5-F6): display selected template name, description, and required parameters to the user for confirmation"
 touchpoints:
-  - T1: "prd011-blazes-templates R4: template directory discovery at well-known or configured path"
-  - T2: "prd011-blazes-templates R5: template file enumeration from directory"
-  - T3: "prd011-blazes-templates R1: Blaze template YAML schema with name, description, tags, parameters"
-  - T4: "prd011-blazes-templates R8: parameter extraction with context inference"
-  - T5: "prd011-blazes-templates R6: tag-based matching of task context against template tags"
-  - T6: "prd011-blazes-templates R7: template selection from matched candidates"
-  - T7: "prd003-crumbs-interface R1: Crumb struct fields referenced in template trail definition"
-  - T8: "prd006-trails-interface R3: trail creation referenced for future instantiation"
+  - T1: "srd011-blazes-templates R4: template directory discovery at well-known or configured path"
+  - T2: "srd011-blazes-templates R5: template file enumeration from directory"
+  - T3: "srd011-blazes-templates R1: Blaze template YAML schema with name, description, tags, parameters"
+  - T4: "srd011-blazes-templates R8: parameter extraction with context inference"
+  - T5: "srd011-blazes-templates R6: tag-based matching of task context against template tags"
+  - T6: "srd011-blazes-templates R7: template selection from matched candidates"
+  - T7: "srd003-crumbs-interface R1: Crumb struct fields referenced in template trail definition"
+  - T8: "srd006-trails-interface R3: trail creation referenced for future instantiation"
 success_criteria:
   - id: S1
     criterion: Template discovery and metadata parsing work end-to-end; agent locates template directory, lists .yaml files, and extracts name, description, tags, and parameters from each — confirming the template pipeline from file system to structured metadata
     traces:
-      - prd011-blazes-templates AC4
-      - prd011-blazes-templates AC6
-      - prd011-blazes-templates AC7
+      - srd011-blazes-templates AC4
+      - srd011-blazes-templates AC6
+      - srd011-blazes-templates AC7
   - id: S2
     criterion: Tag-based matching selects the correct template; task context matches template tags semantically, and the best-matching template is presented with its parameter definitions — confirming selection and parameter extraction compose correctly
     traces:
-      - prd011-blazes-templates AC9
-      - prd011-blazes-templates AC10
+      - srd011-blazes-templates AC9
+      - srd011-blazes-templates AC10
 out_of_scope:
-  - Trail instantiation from template (requires prd-blazes-instantiation)
-  - Parameter value binding and placeholder expansion (requires prd-blazes-instantiation)
-  - Creating crumbs via Table.Set per prd003-crumbs-interface R3 (requires prd-blazes-instantiation)
-  - Creating trails via Table.Set per prd006-trails-interface R3 (requires prd-blazes-instantiation)
-  - Creating belongs_to links per prd006-trails-interface R7 (requires prd-blazes-instantiation)
-  - Template validation and error handling for malformed YAML (requires prd-blazes-schema)
+  - Trail instantiation from template (requires srd-blazes-instantiation)
+  - Parameter value binding and placeholder expansion (requires srd-blazes-instantiation)
+  - Creating crumbs via Table.Set per srd003-crumbs-interface R3 (requires srd-blazes-instantiation)
+  - Creating trails via Table.Set per srd006-trails-interface R3 (requires srd-blazes-instantiation)
+  - Creating belongs_to links per srd006-trails-interface R7 (requires srd-blazes-instantiation)
+  - Template validation and error handling for malformed YAML (requires srd-blazes-schema)
   - Template versioning or inheritance
   - Remote template repositories
   - Template creation or editing workflows

--- a/docs/specs/use-cases/rel99.0-uc002-docker-bootstrap.yaml
+++ b/docs/specs/use-cases/rel99.0-uc002-docker-bootstrap.yaml
@@ -10,8 +10,8 @@ flow:
   - F1: "Build Docker image: create an image with Go toolchain and Claude Code installed, no crumbs source code"
   - F2: "Start container (requires image from F1): mount only the docs/ directory from the host"
   - F3: "Verify environment (requires running container from F2): confirm Go and Claude are available, confirm no existing source code"
-  - F4: "Read documentation (requires docs mount from F2): read VISION.md, ARCHITECTURE.md, road-map.yaml, PRDs, and use cases from the mounted docs directory"
-  - F5: "Plan work items (requires understanding from F4): create a work plan for release 01.0 based on road-map.yaml covering core interfaces from prd001-cupboard-core and SQLite backend from prd002-sqlite-backend"
+  - F4: "Read documentation (requires docs mount from F2): read VISION.md, ARCHITECTURE.md, road-map.yaml, SRDs, and use cases from the mounted docs directory"
+  - F5: "Plan work items (requires understanding from F4): create a work plan for release 01.0 based on road-map.yaml covering core interfaces from srd001-cupboard-core and SQLite backend from srd002-sqlite-backend"
   - F6: "Implement release 01.0 (requires plan from F5): implement pkg/types (Cupboard, Table, Crumb, Config), internal/sqlite (backend, JSONL, directory layout), cmd/crumbs (CLI with config loading)"
   - F7: "Validate use cases (requires implementation from F6): verify success criteria for rel01.0-uc001 (Cupboard lifecycle), rel01.0-uc002 (SQLite CRUD), rel01.0-uc003 (Core CRUD)"
   - F8: "Build and test (requires implementation from F6): compile crumbs and run tests with go build and go test"
@@ -25,25 +25,25 @@ flow:
 touchpoints:
   - T1: "Docker: isolated build environment"
   - T2: "docs/ directory: source of truth for implementation"
-  - T3: "crumbs CLI: work tracking and self-hosting (prd010-configuration-directories R7)"
-  - T4: "Cupboard interface: core storage abstraction with Attach/Detach lifecycle (prd001-cupboard-core R2, R4, R5)"
-  - T5: "Table interface: uniform CRUD operations Get, Set, Delete, Fetch (prd001-cupboard-core R3)"
-  - T6: "Config struct: backend selection and data directory (prd001-cupboard-core R1, prd010-configuration-directories R8)"
-  - T7: "SQLite backend: storage implementation with JSONL source of truth (prd002-sqlite-backend R1-R16)"
-  - T8: "Crumb entity: work item with state lifecycle and properties (prd003-crumbs-interface R1-R11)"
-  - T9: "JSONL files: line-delimited JSON for data persistence (prd010-configuration-directories R3-R4)"
+  - T3: "crumbs CLI: work tracking and self-hosting (srd010-configuration-directories R7)"
+  - T4: "Cupboard interface: core storage abstraction with Attach/Detach lifecycle (srd001-cupboard-core R2, R4, R5)"
+  - T5: "Table interface: uniform CRUD operations Get, Set, Delete, Fetch (srd001-cupboard-core R3)"
+  - T6: "Config struct: backend selection and data directory (srd001-cupboard-core R1, srd010-configuration-directories R8)"
+  - T7: "SQLite backend: storage implementation with JSONL source of truth (srd002-sqlite-backend R1-R16)"
+  - T8: "Crumb entity: work item with state lifecycle and properties (srd003-crumbs-interface R1-R11)"
+  - T9: "JSONL files: line-delimited JSON for data persistence (srd010-configuration-directories R3-R4)"
 success_criteria:
   - id: S1
     criterion: Agent builds a working cupboard from documentation alone inside a fresh container; Attach/Detach lifecycle, Table CRUD, Crumb state transitions, and JSONL persistence all function without pre-existing source code — confirming documentation sufficiency for regeneration
     traces:
-      - prd001-cupboard-core AC1
-      - prd002-sqlite-backend AC1
-      - prd003-crumbs-interface AC1
+      - srd001-cupboard-core AC1
+      - srd002-sqlite-backend AC1
+      - srd003-crumbs-interface AC1
   - id: S2
     criterion: The built cupboard tracks its own remaining work; agent creates crumbs for releases 02.0+ and manages them through state lifecycle using the CLI — confirming self-hosting capability from a documentation-only bootstrap
     traces:
-      - prd009-cupboard-cli AC1
-      - prd010-configuration-directories AC4
+      - srd009-cupboard-cli AC1
+      - srd010-configuration-directories AC4
 out_of_scope:
   - Multi-agent coordination (single agent bootstrap)
   - Continuous integration setup

--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/magefile/mage v1.15.0
-	github.com/mesh-intelligence/cobbler-scaffold v0.20260323.0
+	github.com/mesh-intelligence/cobbler-scaffold v0.20260404.0
 )
 
 require (

--- a/magefiles/go.sum
+++ b/magefiles/go.sum
@@ -1,7 +1,7 @@
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
 github.com/magefile/mage v1.15.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260323.0 h1:npOvG7L6tAPTkahIx9pAI4k+kHG6JekTLwgIGPk8KPE=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260323.0/go.mod h1:7ClERKqRLakydq2mwtElXc/uuNoiHD9SnKxndu8w5yg=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260404.0 h1:YZUwEw/S38QHE0MekTKIQQTu7TXiDPI2yvht9p6ZwFA=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260404.0/go.mod h1:7ClERKqRLakydq2mwtElXc/uuNoiHD9SnKxndu8w5yg=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1 h1:8hho5wd5XU87q91ssEFeJmgS0whm6JTroqtwnaUQxcA=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1/go.mod h1:bH59LsKvDqUtYzW+6MNoaFEjcpMtfdvRNjQDCyfBJ+o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/magefiles/orchestrator.go
+++ b/magefiles/orchestrator.go
@@ -64,88 +64,88 @@ func logf(format string, args ...any) {
 // --- Top-level targets ---
 
 // Init initializes the project.
-func Init() error { return newOrch().Init() }
+func Init() error { return newOrch().Generator.Init() }
 
 // Reset performs a full reset: cobbler and generator.
-func Reset() error { return newOrch().FullReset() }
+func Reset() error { return newOrch().Generator.FullReset() }
 
 // Build compiles the project binary.
-func Build() error { return newOrch().Build() }
+func Build() error { return newOrch().Builder.Build() }
 
 // Lint runs golangci-lint on the project.
-func Lint() error { return newOrch().Lint() }
+func Lint() error { return newOrch().Builder.Lint() }
 
 // Install runs go install for the main package.
-func Install() error { return newOrch().Install() }
+func Install() error { return newOrch().Builder.Install() }
 
 // Clean removes build artifacts.
-func Clean() error { return newOrch().Clean() }
+func Clean() error { return newOrch().Builder.Clean() }
 
 // Credentials extracts Claude credentials from the macOS Keychain.
-func Credentials() error { return newOrch().ExtractCredentials() }
+func Credentials() error { return newOrch().Builder.ExtractCredentials() }
 
-// Analyze performs cross-artifact consistency checks (PRDs, use cases, test suites, roadmap).
-func Analyze() error { return newOrch().Analyze() }
+// Analyze performs cross-artifact consistency checks (SRDs, use cases, test suites, roadmap).
+func Analyze() error { return newOrch().Analyzer.Analyze() }
 
 // Tag creates a documentation release tag (v0.YYYYMMDD.N) and builds the container image.
-func Tag() error { return newOrch().Tag() }
+func Tag() error { return newOrch().Releaser.Tag() }
 
 // --- Scaffold targets ---
 
 // Pop removes orchestrator-managed files from the target repository:
 // magefiles/orchestrator.go, docs/constitutions/, docs/prompts/, and
 // configuration.yaml. Pass "." for the current directory.
-func (Scaffold) Pop(target string) error { return newOrch().Uninstall(target) }
+func (Scaffold) Pop(target string) error { return newOrch().Scaffolder.Uninstall(target) }
 
 // --- Cobbler targets ---
 
 // Measure assesses project state and proposes new tasks via Claude.
-func (Cobbler) Measure() error { return newOrch().Measure() }
+func (Cobbler) Measure() error { return newOrch().Measure.Measure() }
 
 // Stitch picks ready tasks and invokes Claude to execute them.
-func (Cobbler) Stitch() error { return newOrch().Stitch() }
+func (Cobbler) Stitch() error { return newOrch().Stitch.Stitch() }
 
 // Reset removes the cobbler scratch directory.
-func (Cobbler) Reset() error { return newOrch().CobblerReset() }
+func (Cobbler) Reset() error { return newOrch().ClaudeRunner.CobblerReset() }
 
 // --- Generator targets ---
 
 // Start begins a new generation trail.
-func (Generator) Start() error { return newOrch().GeneratorStart() }
+func (Generator) Start() error { return newOrch().Generator.GeneratorStart() }
 
 // Run executes measure + stitch cycles using the generation.cycles value in configuration.yaml.
 // Use RunN to override the cycle count for a single invocation.
-func (Generator) Run() error { return newOrch().GeneratorRun(0) }
+func (Generator) Run() error { return newOrch().Generator.GeneratorRun(0) }
 
 // RunN executes exactly n cycles of measure + stitch within the current generation.
 // Pass n > 0 to override generation.cycles in configuration.yaml for this run only.
-func (Generator) RunN(n int) error { return newOrch().GeneratorRun(n) }
+func (Generator) RunN(n int) error { return newOrch().Generator.GeneratorRun(n) }
 
 // Resume recovers from an interrupted run and continues.
-func (Generator) Resume() error { return newOrch().GeneratorResume() }
+func (Generator) Resume() error { return newOrch().Generator.GeneratorResume() }
 
 // Stop completes a generation trail and merges it into main.
-func (Generator) Stop() error { return newOrch().GeneratorStop() }
+func (Generator) Stop() error { return newOrch().Generator.GeneratorStop() }
 
 // List shows active branches and past generations.
-func (Generator) List() error { return newOrch().GeneratorList() }
+func (Generator) List() error { return newOrch().Generator.GeneratorList() }
 
 // Switch commits current work and checks out another generation branch.
-func (Generator) Switch() error { return newOrch().GeneratorSwitch() }
+func (Generator) Switch() error { return newOrch().Generator.GeneratorSwitch() }
 
 // Reset destroys generation branches, worktrees, and Go source directories.
-func (Generator) Reset() error { return newOrch().GeneratorReset() }
+func (Generator) Reset() error { return newOrch().Generator.GeneratorReset() }
 
 // --- Stats targets ---
 
 // Loc prints Go lines of code and documentation word counts.
-func (Stats) Loc() error { return newOrch().Stats() }
+func (Stats) Loc() error { return newOrch().Stats.PrintStats() }
 
 // Tokens enumerates prompt-attached files and counts tokens via the Anthropic API.
 func (Stats) Tokens() error { return newOrch().TokenStats() }
 
 // Generator prints a status report for the current generation run.
-func (Stats) Generator() error { return newOrch().GeneratorStats() }
+func (Stats) Generator() error { return newOrch().Stats.GeneratorStats() }
 
 // --- Prompt targets ---
 


### PR DESCRIPTION
## Summary

Upgrades scaffolded files to cobbler-scaffold v0.20260404.0 and completes the PRD → SRD rename across the entire codebase. The scaffold upgrade introduced a breaking change (analyzer looks for SRDs not PRDs), so the rename was done together to keep analyze passing. Subsumes GH-60.

## Changes

- Updated orchestrator.go with modular sub-component routing (81 upstream commits)
- Added new constitutions: interface.yaml, semantic-model.yaml
- Updated all existing constitutions and prompts with PRD → SRD terminology
- Added implementation_strategy to go-style.yaml
- Renamed docs/specs/product-requirements/ → docs/specs/software-requirements/
- Renamed 14 prd*.yaml → srd*.yaml files
- Updated all cross-references in 54 files (specs, use cases, test suites, engineering, README)
- Bumped magefiles/go.mod to cobbler-scaffold v0.20260404.0

## Stats

- 66 files changed, 1372 insertions(+), 964 deletions(-)
- spec_words: srd 23,830 | test_suite 15,720 | use_case 14,286 (unchanged)

## Test plan

- [x] `mage analyze` passes with no new errors (same warnings as pre-upgrade)
- [x] Schema validation: 0 errors
- [x] Constitution drift: 0 files
- [x] No remaining prd/PRD references outside .claude/

Closes #54
Closes #60