### PR TITLE
GH-63: Upgrade cobbler-scaffold v0.20260404.0 → v0.20260405.0

### DIFF
--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/magefile/mage v1.15.0
-	github.com/mesh-intelligence/cobbler-scaffold v0.20260404.0
+	github.com/mesh-intelligence/cobbler-scaffold v0.20260405.0
 )
 
 require (

--- a/magefiles/go.sum
+++ b/magefiles/go.sum
@@ -1,7 +1,7 @@
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
 github.com/magefile/mage v1.15.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260404.0 h1:YZUwEw/S38QHE0MekTKIQQTu7TXiDPI2yvht9p6ZwFA=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260404.0/go.mod h1:7ClERKqRLakydq2mwtElXc/uuNoiHD9SnKxndu8w5yg=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260405.0 h1:n83TgZNlj+kAAccyCHZrkhe9RRkbWgvAeWmCkj8BRuo=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260405.0/go.mod h1:7ClERKqRLakydq2mwtElXc/uuNoiHD9SnKxndu8w5yg=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1 h1:8hho5wd5XU87q91ssEFeJmgS0whm6JTroqtwnaUQxcA=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1/go.mod h1:bH59LsKvDqUtYzW+6MNoaFEjcpMtfdvRNjQDCyfBJ+o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=


### PR DESCRIPTION
## Summary

Bumps cobbler-scaffold dependency from v0.20260404.0 to v0.20260405.0. One upstream change: interface specs removed from StandardContextPatterns (no longer auto-included in measure/stitch prompts). No scaffolded file changes.

## Changes

- Bumped `magefiles/go.mod` cobbler-scaffold version
- Updated `magefiles/go.sum`

## Stats

- 2 files changed, 3 insertions(+), 3 deletions(-)

## Test plan

- [x] `mage analyze` passes with no new errors
- [x] Schema validation: 0 errors
- [x] Constitution drift: 0 files

Closes #63