### PR TITLE
GH-29: Add semantic models to 8 SRDs

### DIFF
--- a/docs/specs/software-requirements/srd001-cupboard-core.yaml
+++ b/docs/specs/software-requirements/srd001-cupboard-core.yaml
@@ -166,6 +166,22 @@ package_contract:
   - name: ErrInvalidID
   import_constraints:
   - "pkg/api must not import pkg/schema, internal/, or cmd/"
+semantic_model:
+  observe: |
+    Read ifc-cupboard-and-config.yaml for interface operations and data structures.
+    Read R1-R8 for Config validation, Cupboard lifecycle, Table CRUD, error types,
+    and entity ID generation rules. Read ARCHITECTURE.yaml Interfaces (pkg/api)
+    component for responsibility boundaries.
+  reason: |
+    Define Config struct with Backend and DataDir fields per R1. Define Cupboard
+    interface with GetTable, Attach, Detach per R2. Define Table interface with
+    Get, Set, Delete, Fetch per R3. Define sentinel errors (ErrAlreadyAttached,
+    ErrCupboardDetached, ErrTableNotFound, ErrNotFound, ErrInvalidID) per R7.
+    pkg/api must not import pkg/schema or internal/.
+  produce: |
+    Single file pkg/api/api.go containing Cupboard interface, Table interface,
+    Config struct with Validate method, and sentinel error variables.
+
 non_goals:
 - "This SRD does not define entity-specific schemas or operations. Entity types are defined in their respective interface\
   \ SRDs (srd003-crumbs-interface, srd006-trails-interface, etc.)."

--- a/docs/specs/software-requirements/srd002-sqlite-backend.yaml
+++ b/docs/specs/software-requirements/srd002-sqlite-backend.yaml
@@ -436,6 +436,27 @@ package_contract:
   - internal/persistence must not import cmd/
   - "internal/persistence/engine must not import pkg/schema (entity-agnostic)"
   - internal/persistence/mapping must not import internal/persistence/engine
+semantic_model:
+  observe: |
+    Read ifc-cupboard-and-config.yaml for Cupboard and Table interfaces to implement.
+    Read ifc-entity-types.yaml for all entity struct fields (hydration/persistence targets).
+    Read R1-R16 for directory layout, JSONL format, SQLite schema, startup/shutdown,
+    write operations, concurrency, table routing, hydration, persistence, and sync strategies.
+    Read srd013 and srd014 package contracts for queryutil and lifecycle utilities to consume.
+  reason: |
+    Implement engine (schema creation, JSONL read/write, sync strategy per R3-R4, R16).
+    Implement mapping (one hydrate + one persist function per entity type per R14-R15).
+    Implement table accessors: Get delegates to queryutil.GetByID, Set delegates to
+    lifecycle.UpsertInTx, Delete delegates to lifecycle.DeleteInTx, Fetch delegates
+    to queryutil.FetchRows. Wire table name routing per R12. Implement trail cascade
+    operations (Complete→pebble, Abandon→dust+delete) per R5.
+    internal/persistence must not import cmd/. Engine must not import pkg/schema.
+  produce: |
+    Files in internal/persistence/: engine/engine.go (SQLite lifecycle, schema, JSONL sync),
+    mapping/hydrate.go (per-entity hydration), mapping/persist.go (per-entity persistence),
+    backend.go (NewSQLiteBackend, table routing, Cupboard implementation),
+    and one table accessor file per entity type.
+
 non_goals:
 - "This SRD does not define the Cupboard interface operations. Those are in srd001-cupboard-core and the interface SRDs"
 - "This SRD does not define cross-process locking. Single-process access is assumed"

--- a/docs/specs/software-requirements/srd003-crumbs-interface.yaml
+++ b/docs/specs/software-requirements/srd003-crumbs-interface.yaml
@@ -245,6 +245,23 @@ package_contract:
     signature: "func (c *Crumb) GetProperty(propertyID string) (any, error)"
   import_constraints:
   - pkg/schema must not import pkg/api or internal/
+semantic_model:
+  observe: |
+    Read ifc-entity-types.yaml Crumb data structure for field types and operations.
+    Read R1-R11 for struct fields, state values, state transitions, property methods,
+    filter map keys, and error types. Read srd004 for property value types and categories
+    (SetProperty must validate against them).
+  reason: |
+    Define Crumb struct with CrumbID, Name, State, CreatedAt, UpdatedAt, Properties
+    per R1. Implement state machine (draft→pending→ready→taken→pebble|dust) per R2.
+    Implement Pebble (requires taken state) and Dust per R4. Implement SetProperty
+    with type checking and category validation, GetProperty per R5. All methods
+    modify struct fields only — no I/O, no database knowledge.
+    pkg/schema must not import pkg/api or internal/.
+  produce: |
+    Single file pkg/schema/crumb.go containing Crumb struct and methods:
+    SetState, Pebble, Dust, SetProperty, GetProperty.
+
 non_goals:
 - "This SRD does not define the Table interface or Cupboard interface. See srd001-cupboard-core"
 - "This SRD does not define trail operations. See srd006-trails-interface"

--- a/docs/specs/software-requirements/srd004-properties-interface.yaml
+++ b/docs/specs/software-requirements/srd004-properties-interface.yaml
@@ -248,6 +248,23 @@ package_contract:
     signature: "func (p *Property) DefineCategory(name string, ordinal int) (*Category, error)"
   import_constraints:
   - pkg/schema must not import pkg/api or internal/
+semantic_model:
+  observe: |
+    Read ifc-entity-types.yaml Property and Category data structures for field types.
+    Read R1-R10 for struct fields, value type system (categorical, text, integer,
+    boolean, timestamp, list), default values, category management, built-in
+    properties (priority, status), and error types.
+  reason: |
+    Define Property struct with PropertyID, Name, Description, ValueType, CreatedAt
+    per R1. Define Category struct with CategoryID, PropertyID, Name, Ordinal per R2.
+    Implement value type defaults per R3. Implement DefineCategory with uniqueness
+    validation and categorical-type guard per R7. Implement GetCategories with
+    ordinal+name ordering per R8. All methods modify struct fields only.
+    pkg/schema must not import pkg/api or internal/.
+  produce: |
+    Single file pkg/schema/property.go containing Property struct, Category struct,
+    DefineCategory, GetCategories, and value type default functions.
+
 non_goals:
 - "This SRD does not define setting or getting property values on crumbs. See srd003-crumbs-interface for SetProperty, GetProperty,\
   \ GetProperties, and ClearProperty"

--- a/docs/specs/software-requirements/srd006-trails-interface.yaml
+++ b/docs/specs/software-requirements/srd006-trails-interface.yaml
@@ -214,6 +214,24 @@ package_contract:
     signature: "func (t *Trail) Abandon() error"
   import_constraints:
   - pkg/schema must not import pkg/api or internal/
+semantic_model:
+  observe: |
+    Read ifc-entity-types.yaml Trail data structure for field types and operations.
+    Read R1-R9 for struct fields, state values, state transitions, Complete/Abandon
+    semantics, crumb membership via belongs_to links, and trail branching via
+    branches_from links.
+  reason: |
+    Define Trail struct with TrailID, State, CreatedAt, CompletedAt per R1.
+    Implement state machine (draft→pending→active→completed|abandoned) per R2.
+    Implement Complete: requires active state, sets State and CompletedAt per R5.
+    Implement Abandon: requires active state, sets State and CompletedAt per R6.
+    Both methods modify struct fields only; cascade operations (crumbs to pebble
+    or dust) are the backend's responsibility in srd002.
+    pkg/schema must not import pkg/api or internal/.
+  produce: |
+    Single file pkg/schema/trail.go containing Trail struct and methods:
+    Complete, Abandon.
+
 non_goals:
 - "This SRD does not define crumb CRUD operations. See srd003-crumbs-interface."
 - "This SRD does not define the Table interface or link storage. The Table interface is defined in srd001-cupboard-core and\

--- a/docs/specs/software-requirements/srd008-stash-interface.yaml
+++ b/docs/specs/software-requirements/srd008-stash-interface.yaml
@@ -268,6 +268,24 @@ package_contract:
     signature: "func (s *Stash) Release(holder string) error"
   import_constraints:
   - pkg/schema must not import pkg/api or internal/
+semantic_model:
+  observe: |
+    Read ifc-entity-types.yaml Stash data structure for field types and operations.
+    Read R1-R13 for struct fields, stash types (resource, artifact, context, counter,
+    lock), value operations, history tracking, scoping via scoped_to links, and
+    error types.
+  reason: |
+    Define Stash struct with StashID, Name, StashType, Value, Version, CreatedAt
+    per R1. Define StashHistoryEntry per R7. Implement SetValue: reject lock type,
+    increment version per R4. Implement Increment: validate counter type, add delta
+    per R5. Implement Acquire: validate lock type, check reentrant, set holder per R6.
+    Implement Release: validate lock type, verify holder, clear lock per R6.
+    All methods modify struct fields only — no I/O, no database knowledge.
+    pkg/schema must not import pkg/api or internal/.
+  produce: |
+    Single file pkg/schema/stash.go containing Stash struct, StashHistoryEntry
+    struct, and methods: SetValue, Increment, Acquire, Release.
+
 non_goals:
 - This SRD does not define queue or channel stash types. These may be added in a future version
 - "This SRD does not define stash replication or cross-cupboard sharing"

--- a/docs/specs/software-requirements/srd013-table-query-helpers.yaml
+++ b/docs/specs/software-requirements/srd013-table-query-helpers.yaml
@@ -108,6 +108,23 @@ requirements:
         text: "Provide CheckUnique that runs a uniqueness query and returns ErrDuplicateName if a matching row exists (excluding\
           \ the current entity's ID)"
         weight: 2
+semantic_model:
+  observe: |
+    Read R1-R6 for Scanner interface, filter building, pagination, result iteration,
+    single-row retrieval, and existence checks. Read srd002 R13-R15 for how table
+    accessors consume these utilities (hydration callbacks, filter map patterns).
+  reason: |
+    Define Scanner interface unifying *sql.Row and *sql.Rows per R1. Implement
+    AddStringFilter and AddIntFilter to extract filter map values and append SQL
+    WHERE conditions per R2. Implement ApplyLimitOffset per R3. Implement FetchRows
+    with Scanner-based hydration callback per R4. Implement GetByID with ErrNoRows
+    to ErrNotFound mapping per R5. Implement CheckExists and CheckUnique per R6.
+    No entity type imports; operate on database/sql and pkg/api types only.
+  produce: |
+    Single file internal/persistence/queryutil/queryutil.go containing Scanner
+    interface, AddStringFilter, AddIntFilter, ApplyLimitOffset, FetchRows,
+    GetByID, CheckExists, CheckUnique.
+
 non_goals:
 - "This SRD does not define entity-specific hydration logic. Each table accessor still defines its own hydration function;\
   \ this SRD provides the Scanner interface they accept"

--- a/docs/specs/software-requirements/srd014-entity-lifecycle-helpers.yaml
+++ b/docs/specs/software-requirements/srd014-entity-lifecycle-helpers.yaml
@@ -86,6 +86,22 @@ requirements:
         text: "Callers use the delete callback to execute entity-specific CASCADE deletes (e.g., deleting a crumb's properties,\
           \ metadata, and links within the same transaction)"
         weight: 5
+semantic_model:
+  observe: |
+    Read R1-R3 for UUID v7 generation, upsert scaffolding, and delete scaffolding.
+    Read srd002 R5 and R11 for how table accessors consume these utilities
+    (transaction callbacks, existence check patterns).
+  reason: |
+    Implement NewEntityID: generate UUID v7, extract UTC timestamp per R1.
+    Implement UpsertInTx: begin transaction, check existence via SQL query,
+    call onInsert or onUpdate callback, commit, return inserted boolean per R2.
+    Implement DeleteInTx: validate ID non-empty, check existence, call onDelete
+    callback within transaction, commit per R3. No entity type imports;
+    callbacks provide entity-specific SQL. Uses database/sql and github.com/google/uuid.
+  produce: |
+    Single file internal/persistence/lifecycle/lifecycle.go containing
+    NewEntityID, UpsertInTx, DeleteInTx.
+
 non_goals:
 - "This SRD does not define JSONL persistence after commit. Table accessors handle JSONL writes after the transaction completes,\
   \ since JSONL file selection varies by entity type"


### PR DESCRIPTION
## Summary

Added observe/reason/produce semantic models to 8 SRDs that have package contracts. Each model describes what the implementing agent reads, what implementation decisions it makes, and what Go source files it produces. Updated issue title from PRD to SRD terminology.

## Changes

- Added `semantic_model` with observe/reason/produce to srd001, srd002, srd003, srd004, srd006, srd008, srd013, srd014
- Re-created recurring issue as GH-69 with updated SRD terminology

## Stats

- 8 files changed, 140 insertions
- spec_words: srd 24,819 (+941), test_suite 15,720, use_case 14,286

## Test plan

- [x] `mage analyze` semantic model validation: 0 errors
- [x] Schema validation: 8 false-positive errors from upstream `KnownFields(true)` bug with `*yaml.Node`
- [x] All 8 semantic models use correct shorthand format (observe/reason/produce)

Closes #29