### PR TITLE
GH-27: Add package_contract to 4 SRDs

### DIFF
--- a/docs/specs/software-requirements/srd005-metadata-interface.yaml
+++ b/docs/specs/software-requirements/srd005-metadata-interface.yaml
@@ -217,6 +217,15 @@ requirements:
     - R10.2:
         text: All errors must be checkable with errors.Is
         weight: 1
+package_contract:
+  exports:
+  - name: Metadata
+    signature: "type Metadata struct { MetadataID string; CrumbID string; TableName string; PropertyID string; Content string; CreatedAt time.Time }"
+  - name: Schema
+    signature: "type Schema struct { SchemaName string; Description string; ContentType string }"
+  import_constraints:
+  - pkg/schema must not import pkg/api or internal/
+
 non_goals:
 - "This SRD does not define the Table interface or Cupboard interface. See srd001-cupboard-core."
 - "This SRD does not define crumb operations. See srd003-crumbs-interface."

--- a/docs/specs/software-requirements/srd007-links-interface.yaml
+++ b/docs/specs/software-requirements/srd007-links-interface.yaml
@@ -158,6 +158,18 @@ requirements:
     - R8.5:
         text: "Audit functions are also available as Cupboard methods for on-demand validation"
         weight: 8
+package_contract:
+  exports:
+  - name: Link
+    signature: "type Link struct { LinkID string; LinkType string; FromID string; ToID string; CreatedAt time.Time }"
+  - name: ValidateDAG
+    signature: "func ValidateDAG(cupboard api.Cupboard) error"
+  - name: ValidateReferences
+    signature: "func ValidateReferences(cupboard api.Cupboard) error"
+  import_constraints:
+  - pkg/schema must not import pkg/api or internal/
+  - "Graph audit functions may import pkg/api for Cupboard access"
+
 non_goals:
 - "This SRD does not define cascade behavior on trail completion or abandonment. See srd006-trails-interface for cascade semantics"
 - "This SRD does not define entity-specific query patterns (e.g., finding all crumbs in a trail). Those patterns are documented\

--- a/docs/specs/software-requirements/srd010-configuration-directories.yaml
+++ b/docs/specs/software-requirements/srd010-configuration-directories.yaml
@@ -165,6 +165,18 @@ requirements:
         text: CLI configuration (config.yaml) is outside the Cupboard interface. The CLI reads config.yaml and constructs
           a Config struct to pass to Attach
         weight: 1
+package_contract:
+  exports:
+  - name: ResolveConfigDir
+    signature: "func ResolveConfigDir(flagValue string) (string, error)"
+  - name: LoadConfig
+    signature: "func LoadConfig(configDir string) (api.Config, error)"
+  - name: DefaultConfigDir
+    signature: "func DefaultConfigDir() (string, error)"
+  import_constraints:
+  - "Configuration resolution may import pkg/api for Config struct"
+  - "Must not import internal/ packages"
+
 non_goals:
 - This SRD does not define configuration file encryption or secrets management.
 - "This SRD does not define multi-workspace support (multiple data directories). One CLI instance operates on one data directory\

--- a/docs/specs/software-requirements/srd011-blazes-templates.yaml
+++ b/docs/specs/software-requirements/srd011-blazes-templates.yaml
@@ -447,6 +447,31 @@ requirements:
         text: "I/O errors reading individual template files (e.g., file deleted between listing and reading) must be treated\
           \ as warnings. The parser skips the unreadable file and continues with remaining files"
         weight: 1
+package_contract:
+  exports:
+  - name: BlazeMetadata
+    signature: "type BlazeMetadata struct { Name string; Description string; Tags []string; Parameters []BlazeParameter; Version string; Priority int; Author string; FilePath string }"
+  - name: BlazeParameter
+    signature: "type BlazeParameter struct { Name string; Description string; Type string; Default string }"
+  - name: SelectionResult
+    signature: "type SelectionResult struct { Selected *BlazeMetadata; Tied []*BlazeMetadata; Ambiguous bool; NoMatch bool }"
+  - name: ExtractedParameter
+    signature: "type ExtractedParameter struct { Name string; Description string; Type string; Default string; Required bool; InferredValue string; Inferred bool }"
+  - name: DiscoverTemplateDir
+    signature: "func DiscoverTemplateDir(path string) (string, error)"
+  - name: ListTemplates
+    signature: "func ListTemplates(dir string) ([]string, error)"
+  - name: ParseTemplates
+    signature: "func ParseTemplates(paths []string) ([]BlazeMetadata, []error)"
+  - name: MatchTemplates
+    signature: "func MatchTemplates(templates []BlazeMetadata, tags []string) []BlazeMetadata"
+  - name: SelectTemplate
+    signature: "func SelectTemplate(matched []BlazeMetadata) SelectionResult"
+  - name: ExtractParameters
+    signature: "func ExtractParameters(template *BlazeMetadata) []ExtractedParameter"
+  import_constraints:
+  - "pkg/blazes must not import pkg/api, pkg/schema, or internal/"
+
 non_goals:
 - "This SRD does not define trail instantiation from templates. Creating trails, crumbs, and belongs_to links from a selected\
   \ template is deferred to srd-blazes-instantiation"


### PR DESCRIPTION
## Summary

Added package_contract fields with exports and import_constraints to the 4 remaining SRDs that define package-level exports. All 12 SRDs with implementation code now have package_contract fields.

## Changes

- Added `package_contract` to srd005 (Metadata/Schema structs), srd007 (Link struct, graph audit), srd010 (config resolution), srd011 (blazes templates)
- Skipped srd009 (CLI, no package exports) and srd012 (architecture constraints, no exports)
- Re-created recurring issue as GH-71 with SRD terminology

## Stats

- 4 files changed, 58 insertions
- spec_words: srd 25,113 (+294), test_suite 15,720, use_case 14,286

## Test plan

- [x] `mage analyze` passes with no new errors
- [x] Schema validation: same 8 pre-existing false positives (upstream yaml.Node bug)
- [x] All package_contract exports consistent with SRD requirements

Closes #27